### PR TITLE
Fix browser module MIME/loading failures in app bootstrap

### DIFF
--- a/canvas.js
+++ b/canvas.js
@@ -1,0 +1,5 @@
+/**
+ * canvas.js — browser-compatible shim.
+ * Re-exports the default app shell from the JSX implementation.
+ */
+export { default } from './js/coorcanvas/CoorCanvas_AppShell.jsx';

--- a/js/coord2pcf/coord2pcf-tab.js
+++ b/js/coord2pcf/coord2pcf-tab.js
@@ -705,7 +705,7 @@ async function _mountCanvas() {
       await Promise.all([
         import('react'),
         import('react-dom/client'),
-        import('../../canvas.jsx'),
+        import('../../canvas.js'),
       ]);
     _canvasRoot = createRoot(mountEl);
     _canvasRoot.render(
@@ -729,7 +729,7 @@ async function _mountCanvas() {
 function _refreshCanvas(forceKey = null) {
   if (!_canvasRoot) return;
   import('react').then(({ default: React }) => {
-    import('../../canvas.jsx').then(({ default: PcfGeneratorUI }) => {
+    import('../../canvas.js').then(({ default: PcfGeneratorUI }) => {
       const route = _parsedRuns.length
         ? _parsedRuns.flatMap(r => r.points).map(p => [p.x, p.y])
         : null;

--- a/js/ray-app.js
+++ b/js/ray-app.js
@@ -7,10 +7,9 @@ import { initRayConceptTab }   from './ray-concept/rc-tab.js';
 import { initRayViewerTab }    from './ray-tabs/ray-viewer-tab.js';
 import { initRayMasterData }   from './ray-tabs/ray-masterdata-tab.js';
 import { themeManager }        from './ui/theme-manager.js';
-import { initPcfGlbExporterPanel } from './pcf2glb/ui/PcfGlbExporterPanelWrapper.jsx';
 import { APP_REVISION } from './ui/status-bar.js';
 
-const TABS = ['ray', 'viewer', 'masterdata', 'pcf-fixer', 'coord2pcf', 'pcf2glb'];
+const TABS = ['ray', 'viewer', 'masterdata', 'pcf-fixer', 'coord2pcf'];
 
 function switchTab(target) {
   const panelMap = {
@@ -18,8 +17,7 @@ function switchTab(target) {
     'viewer': 'viewer',
     'masterdata': 'masterdata',
     'pcf-fixer': 'pcf-fixer',
-    'coord2pcf': 'coord2pcf',
-    'pcf2glb': 'pcf2glb'
+    'coord2pcf': 'coord2pcf'
   };
   TABS.forEach(id => {
     document.getElementById(`rtab-${id}`)?.classList.toggle('active', id === target);

--- a/js/ray-tabs/ray-viewer-tab.js
+++ b/js/ray-tabs/ray-viewer-tab.js
@@ -78,11 +78,11 @@ async function _runGenerate() {
     // Mount React 3D app then reveal the canvas
     let mountReactApp;
     try {
-      ({ mountReactApp } = await import('../editor/App.jsx'));
-    } catch (jsxError) {
-      console.warn(`${LOG_PREFIX} App.jsx import failed, retrying bundle`, jsxError);
       const bundleUrl = new URL('../editor/App.bundle.js', import.meta.url).href;
       ({ mountReactApp } = await import(/* @vite-ignore */ bundleUrl));
+    } catch (bundleError) {
+      console.warn(`${LOG_PREFIX} App.bundle.js import failed, retrying App.jsx`, bundleError);
+      ({ mountReactApp } = await import('../editor/App.jsx'));
     }
     mountReactApp('react-root', { components: _processed.components });
     const reactRoot = document.getElementById('react-root');

--- a/js/ui/viewer-tab.js
+++ b/js/ui/viewer-tab.js
@@ -474,11 +474,11 @@ async function _render3D() {
         try {
             let mountReactApp;
             try {
-                ({ mountReactApp } = await import('../editor/App.jsx'));
-            } catch (jsxError) {
-                console.warn('[ViewerTab] Vite import failed, retrying browser bundle', jsxError);
                 const bundleUrl = new URL('../editor/App.bundle.js', import.meta.url).href;
                 ({ mountReactApp } = await import(/* @vite-ignore */ bundleUrl));
+            } catch (bundleError) {
+                console.warn('[ViewerTab] Bundle import failed, retrying Vite App.jsx', bundleError);
+                ({ mountReactApp } = await import('../editor/App.jsx'));
             }
 
             const { registerUpdateCallback } = await import('../editor/store.js');


### PR DESCRIPTION
### Motivation
- The app failed to load in static/browser mode because the browser attempted to fetch `.jsx` files that are served with `text/jsx`, causing strict MIME-type module script errors. 
- Runtime lazy imports referencing JSX entrypoints caused startup failures when hosted statically. 
- The goal is to route runtime imports through browser-safe entry points and existing prebuilt bundles so the UI initializes reliably in both dev and static-host environments.

### Description
- Removed the top-level import of `PcfGlbExporterPanelWrapper.jsx` and the stale `pcf2glb` tab routing from `js/ray-app.js` to avoid fetching `.jsx` at bootstrap. 
- Added a `canvas.js` browser shim that re-exports `./js/coorcanvas/CoorCanvas_AppShell.jsx` so consumers can import a `.js` entrypoint. 
- Switched Coord→PCF lazy imports from `../../canvas.jsx` to the new `../../canvas.js` in `js/coord2pcf/coord2pcf-tab.js`. 
- Updated the 3D viewer loaders in `js/ray-tabs/ray-viewer-tab.js` and `js/ui/viewer-tab.js` to prefer the prebuilt `App.bundle.js` and fall back to `App.jsx` only on bundle import failure.

### Testing
- Ran `npm run build` which completed successfully (Vite build finished and produced `dist/` assets). 
- The modified files were committed after making the changes (`git commit` completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e45881951c832e8a2a0fc6730f0bfa)