### PR TITLE
Canvas shim + import fallback fixes, remove pcf2glb tab, and add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy on Merge to Main
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  deploy:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy
+        run: echo "Add your deployment command here (e.g. Vercel, S3, SSH, etc.)"

--- a/canvas.js
+++ b/canvas.js
@@ -1,0 +1,5 @@
+/**
+ * canvas.js — browser-compatible shim.
+ * Re-exports the default app shell from the JSX implementation.
+ */
+export { default } from './js/coorcanvas/CoorCanvas_AppShell.jsx';

--- a/js/coord2pcf/coord2pcf-tab.js
+++ b/js/coord2pcf/coord2pcf-tab.js
@@ -705,7 +705,7 @@ async function _mountCanvas() {
       await Promise.all([
         import('react'),
         import('react-dom/client'),
-        import('../../canvas.jsx'),
+        import('../../canvas.js'),
       ]);
     _canvasRoot = createRoot(mountEl);
     _canvasRoot.render(
@@ -729,7 +729,7 @@ async function _mountCanvas() {
 function _refreshCanvas(forceKey = null) {
   if (!_canvasRoot) return;
   import('react').then(({ default: React }) => {
-    import('../../canvas.jsx').then(({ default: PcfGeneratorUI }) => {
+    import('../../canvas.js').then(({ default: PcfGeneratorUI }) => {
       const route = _parsedRuns.length
         ? _parsedRuns.flatMap(r => r.points).map(p => [p.x, p.y])
         : null;

--- a/js/ray-app.js
+++ b/js/ray-app.js
@@ -7,10 +7,9 @@ import { initRayConceptTab }   from './ray-concept/rc-tab.js';
 import { initRayViewerTab }    from './ray-tabs/ray-viewer-tab.js';
 import { initRayMasterData }   from './ray-tabs/ray-masterdata-tab.js';
 import { themeManager }        from './ui/theme-manager.js';
-import { initPcfGlbExporterPanel } from './pcf2glb/ui/PcfGlbExporterPanelWrapper.jsx';
 import { APP_REVISION } from './ui/status-bar.js';
 
-const TABS = ['ray', 'viewer', 'masterdata', 'pcf-fixer', 'coord2pcf', 'pcf2glb'];
+const TABS = ['ray', 'viewer', 'masterdata', 'pcf-fixer', 'coord2pcf'];
 
 function switchTab(target) {
   const panelMap = {
@@ -18,8 +17,7 @@ function switchTab(target) {
     'viewer': 'viewer',
     'masterdata': 'masterdata',
     'pcf-fixer': 'pcf-fixer',
-    'coord2pcf': 'coord2pcf',
-    'pcf2glb': 'pcf2glb'
+    'coord2pcf': 'coord2pcf'
   };
   TABS.forEach(id => {
     document.getElementById(`rtab-${id}`)?.classList.toggle('active', id === target);

--- a/js/ray-tabs/ray-viewer-tab.js
+++ b/js/ray-tabs/ray-viewer-tab.js
@@ -78,11 +78,11 @@ async function _runGenerate() {
     // Mount React 3D app then reveal the canvas
     let mountReactApp;
     try {
-      ({ mountReactApp } = await import('../editor/App.jsx'));
-    } catch (jsxError) {
-      console.warn(`${LOG_PREFIX} App.jsx import failed, retrying bundle`, jsxError);
       const bundleUrl = new URL('../editor/App.bundle.js', import.meta.url).href;
       ({ mountReactApp } = await import(/* @vite-ignore */ bundleUrl));
+    } catch (bundleError) {
+      console.warn(`${LOG_PREFIX} App.bundle.js import failed, retrying App.jsx`, bundleError);
+      ({ mountReactApp } = await import('../editor/App.jsx'));
     }
     mountReactApp('react-root', { components: _processed.components });
     const reactRoot = document.getElementById('react-root');

--- a/js/ui/viewer-tab.js
+++ b/js/ui/viewer-tab.js
@@ -474,11 +474,11 @@ async function _render3D() {
         try {
             let mountReactApp;
             try {
-                ({ mountReactApp } = await import('../editor/App.jsx'));
-            } catch (jsxError) {
-                console.warn('[ViewerTab] Vite import failed, retrying browser bundle', jsxError);
                 const bundleUrl = new URL('../editor/App.bundle.js', import.meta.url).href;
                 ({ mountReactApp } = await import(/* @vite-ignore */ bundleUrl));
+            } catch (bundleError) {
+                console.warn('[ViewerTab] Bundle import failed, retrying Vite App.jsx', bundleError);
+                ({ mountReactApp } = await import('../editor/App.jsx'));
             }
 
             const { registerUpdateCallback } = await import('../editor/store.js');


### PR DESCRIPTION
### Motivation
- Provide a browser-compatible entry for the canvas UI so runtime consumers can import a plain JS module instead of a JSX bundle.
- Make dynamic imports for the React editor/viewer more robust by improving fallback ordering and error logging to handle both Vite and prebuilt bundle scenarios.
- Remove the now-unused `pcf2glb` tab and related import from the Ray landing page.
- Add a simple GitHub Actions deployment workflow to run a build and allow adding a deployment command on merge to `main`.

### Description
- Added `.github/workflows/deploy.yml` which runs on merged pull requests to `main` and executes `checkout`, `actions/setup-node@v4` (Node 20), `npm ci`, `npm run build`, and a placeholder `Deploy` step.
- Added `canvas.js` as a browser-compatible shim that `export { default } from './js/coorcanvas/CoorCanvas_AppShell.jsx';` to provide a plain JS entry point for the canvas app.
- Updated runtime imports to use the new shim (`../../canvas.js`) in `js/coord2pcf/coord2pcf-tab.js` so the canvas preview mounts correctly in browser bundle setups.
- Adjusted dynamic import fallback logic and error handling in `js/ray-tabs/ray-viewer-tab.js` and `js/ui/viewer-tab.js` to more reliably try a bundle and then retry the Vite `App.jsx` (and vice-versa where appropriate) and to improve logging variable names for clarity.
- Removed the `pcf2glb` tab and its wrapper import from `js/ray-app.js` and updated the `TABS` list accordingly.

### Testing
- Executed `npm ci` and `npm run build` as part of validation and the build completed successfully.
- Added the GitHub Actions workflow which will run `npm ci` and `npm run build` automatically on merged PRs to `main` (build step included and expected to succeed when run in CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e45881951c832e8a2a0fc6730f0bfa)