### PR TITLE
Add deploy workflow, introduce canvas.js shim, remove pcf2glb wrapper and harden dynamic imports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy on Merge to Main
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  deploy:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy
+        run: echo "Add your deployment command here (e.g. Vercel, S3, SSH, etc.)"

--- a/canvas.js
+++ b/canvas.js
@@ -1,0 +1,5 @@
+/**
+ * canvas.js — browser-compatible shim.
+ * Re-exports the default app shell from the JSX implementation.
+ */
+export { default } from './js/coorcanvas/CoorCanvas_AppShell.jsx';

--- a/js/coord2pcf/coord2pcf-tab.js
+++ b/js/coord2pcf/coord2pcf-tab.js
@@ -705,7 +705,7 @@ async function _mountCanvas() {
       await Promise.all([
         import('react'),
         import('react-dom/client'),
-        import('../../canvas.jsx'),
+        import('../../canvas.js'),
       ]);
     _canvasRoot = createRoot(mountEl);
     _canvasRoot.render(
@@ -729,7 +729,7 @@ async function _mountCanvas() {
 function _refreshCanvas(forceKey = null) {
   if (!_canvasRoot) return;
   import('react').then(({ default: React }) => {
-    import('../../canvas.jsx').then(({ default: PcfGeneratorUI }) => {
+    import('../../canvas.js').then(({ default: PcfGeneratorUI }) => {
       const route = _parsedRuns.length
         ? _parsedRuns.flatMap(r => r.points).map(p => [p.x, p.y])
         : null;

--- a/js/pcf2glb/ui/PcfGlbExporterPanelWrapper.jsx
+++ b/js/pcf2glb/ui/PcfGlbExporterPanelWrapper.jsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import { PcfGlbExporterPanel } from './PcfGlbExporterPanel.jsx';
-
-export function initPcfGlbExporterPanel(container) {
-  if (!container) return;
-  const root = createRoot(container);
-  root.render(<PcfGlbExporterPanel />);
-}

--- a/js/ray-app.js
+++ b/js/ray-app.js
@@ -7,10 +7,9 @@ import { initRayConceptTab }   from './ray-concept/rc-tab.js';
 import { initRayViewerTab }    from './ray-tabs/ray-viewer-tab.js';
 import { initRayMasterData }   from './ray-tabs/ray-masterdata-tab.js';
 import { themeManager }        from './ui/theme-manager.js';
-import { initPcfGlbExporterPanel } from './pcf2glb/ui/PcfGlbExporterPanelWrapper.jsx';
 import { APP_REVISION } from './ui/status-bar.js';
 
-const TABS = ['ray', 'viewer', 'masterdata', 'pcf-fixer', 'coord2pcf', 'pcf2glb'];
+const TABS = ['ray', 'viewer', 'masterdata', 'pcf-fixer', 'coord2pcf'];
 
 function switchTab(target) {
   const panelMap = {
@@ -18,8 +17,7 @@ function switchTab(target) {
     'viewer': 'viewer',
     'masterdata': 'masterdata',
     'pcf-fixer': 'pcf-fixer',
-    'coord2pcf': 'coord2pcf',
-    'pcf2glb': 'pcf2glb'
+    'coord2pcf': 'coord2pcf'
   };
   TABS.forEach(id => {
     document.getElementById(`rtab-${id}`)?.classList.toggle('active', id === target);

--- a/js/ray-tabs/ray-viewer-tab.js
+++ b/js/ray-tabs/ray-viewer-tab.js
@@ -78,11 +78,11 @@ async function _runGenerate() {
     // Mount React 3D app then reveal the canvas
     let mountReactApp;
     try {
-      ({ mountReactApp } = await import('../editor/App.jsx'));
-    } catch (jsxError) {
-      console.warn(`${LOG_PREFIX} App.jsx import failed, retrying bundle`, jsxError);
       const bundleUrl = new URL('../editor/App.bundle.js', import.meta.url).href;
       ({ mountReactApp } = await import(/* @vite-ignore */ bundleUrl));
+    } catch (bundleError) {
+      console.warn(`${LOG_PREFIX} App.bundle.js import failed, retrying App.jsx`, bundleError);
+      ({ mountReactApp } = await import('../editor/App.jsx'));
     }
     mountReactApp('react-root', { components: _processed.components });
     const reactRoot = document.getElementById('react-root');

--- a/js/ui/viewer-tab.js
+++ b/js/ui/viewer-tab.js
@@ -474,11 +474,11 @@ async function _render3D() {
         try {
             let mountReactApp;
             try {
-                ({ mountReactApp } = await import('../editor/App.jsx'));
-            } catch (jsxError) {
-                console.warn('[ViewerTab] Vite import failed, retrying browser bundle', jsxError);
                 const bundleUrl = new URL('../editor/App.bundle.js', import.meta.url).href;
                 ({ mountReactApp } = await import(/* @vite-ignore */ bundleUrl));
+            } catch (bundleError) {
+                console.warn('[ViewerTab] Bundle import failed, retrying Vite App.jsx', bundleError);
+                ({ mountReactApp } = await import('../editor/App.jsx'));
             }
 
             const { registerUpdateCallback } = await import('../editor/store.js');


### PR DESCRIPTION
### Motivation
- Add a deployment GitHub Actions workflow to run a build and trigger a deploy on merged PRs to `main`.
- Provide a browser-compatible `canvas.js` shim so code can import a non-JSX entrypoint in non-bundled environments.
- Remove the legacy PCF→GLB exporter wrapper and associated UI tab to simplify the app surface.
- Make runtime dynamic imports more resilient by swapping retry order and improving warnings when loading the React editor bundle.

### Description
- Added `.github/workflows/deploy.yml` which triggers on closed PRs merged into `main` and runs `npm ci`, `npm run build`, and a placeholder `Deploy` command.
- Introduced `canvas.js` that re-exports the default app shell from `./js/coorcanvas/CoorCanvas_AppShell.jsx` and updated `js/coord2pcf/coord2pcf-tab.js` to import `../../canvas.js` for both mount and refresh flows.
- Deleted `js/pcf2glb/ui/PcfGlbExporterPanelWrapper.jsx` and removed its import and the `pcf2glb` tab from `js/ray-app.js` and the `TABS` list.
- Adjusted dynamic import retry logic and logging in `js/ray-tabs/ray-viewer-tab.js` and `js/ui/viewer-tab.js` to try the alternate bundle/source on failure with clearer console warnings.

### Testing
- No automated unit tests were changed or added for this PR.
- The repository now includes a deploy workflow that will run `npm ci` and `npm run build` on merge to `main` as part of CI.
- A local `npm run build` was executed to validate that the editor bundle import changes do not break the build (build completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e45881951c832e8a2a0fc6730f0bfa)