### PR TITLE
Phase 2 Common PCF Builder model emitter and diff harness

### DIFF
--- a/js/pcf-engine/brlen-resolver.js
+++ b/js/pcf-engine/brlen-resolver.js
@@ -1,0 +1,178 @@
+/**
+ * brlen-resolver.js — Phase 4D BRLEN fallback resolver
+ *
+ * Priority:
+ *  1. Direct Data Table BRLEN
+ *  2. Calculated magnitude BP - CP
+ *  3. TEE equal/reducing ASME lookup through existing app services/config
+ *  4. OLET A + 0.5 × Header OD through existing app services/config
+ *  5. Incomplete diagnostic
+ */
+
+import { getRayConfig, lookupTeeBreln, lookupOletBrlen } from '../ray-concept/rc-config.js';
+import { getTeeBrlen, getOletBrlen } from '../services/fallbackcontract.js';
+
+function n(value, fallback = null) {
+  if (value == null || value === '') return fallback;
+  const x = Number(value);
+  return Number.isFinite(x) ? x : fallback;
+}
+
+function clean(value) {
+  return String(value ?? '').trim();
+}
+
+function point(value) {
+  if (!value || typeof value !== 'object') return null;
+  const x = n(value.x), y = n(value.y), z = n(value.z);
+  return [x, y, z].every(v => v != null) ? { x, y, z } : null;
+}
+
+function mag(a, b) {
+  const pa = point(a), pb = point(b);
+  if (!pa || !pb) return null;
+  const dx = pb.x - pa.x;
+  const dy = pb.y - pa.y;
+  const dz = pb.z - pa.z;
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+function typeOf(component) {
+  return clean(component?.type || component?.rawType).toUpperCase();
+}
+
+function brlenFromServiceOrConfigForTee(headerBore, branchBore, cfg) {
+  const h = n(headerBore), b = n(branchBore ?? headerBore);
+  if (h == null || b == null) return null;
+
+  const fromService = getTeeBrlen(h, b);
+  if (fromService != null) return { value: fromService, source: 'masterTableService.getTeeBrlen' };
+
+  const fromConfig = lookupTeeBreln(h, b, cfg);
+  if (fromConfig != null) return { value: fromConfig, source: 'rc-config.lookupTeeBreln' };
+
+  return null;
+}
+
+function brlenFromServiceOrConfigForOlet(headerBore, branchBore, cfg) {
+  const h = n(headerBore), b = n(branchBore ?? 50);
+  if (h == null || b == null) return null;
+
+  const fromService = getOletBrlen(h, b);
+  if (fromService != null) return { value: fromService, source: 'masterTableService.getOletBrlen' };
+
+  const fromConfig = lookupOletBrlen(h, b, cfg);
+  if (fromConfig != null) return { value: fromConfig, source: 'rc-config.lookupOletBrlen' };
+
+  return null;
+}
+
+export function resolveBrlen(component, options = {}) {
+  const cfg = options.cfg || getRayConfig();
+  const diagnostics = [];
+  const t = typeOf(component);
+
+  const direct = n(component?.brlen ?? component?.branchLength ?? component?.BRLEN);
+  if (direct != null && direct > 0) {
+    return {
+      brlen: direct,
+      source: 'direct-data-table',
+      complete: true,
+      diagnostics,
+    };
+  }
+
+  const geom = mag(component?.cp, component?.bp);
+  if (geom != null && geom > 0) {
+    return {
+      brlen: geom,
+      source: 'calculated-bp-minus-cp',
+      complete: true,
+      diagnostics,
+    };
+  }
+
+  const headerBore = n(component?.bore ?? component?.headerBore ?? component?.mainBore);
+  const branchBore = n(component?.branchBore ?? component?.branch_bore);
+
+  if (t === 'TEE') {
+    const hit = brlenFromServiceOrConfigForTee(headerBore, branchBore ?? headerBore, cfg);
+    if (hit?.value != null) {
+      return {
+        brlen: hit.value,
+        source: hit.source,
+        complete: true,
+        diagnostics,
+      };
+    }
+    diagnostics.push({
+      severity: 'error',
+      code: 'BRLEN-TEE-MISSING',
+      message: 'TEE BRLEN unresolved: no direct BRLEN, no BP/CP geometry, and no ASME tee table match.',
+      headerBore,
+      branchBore: branchBore ?? headerBore,
+    });
+  } else if (t === 'OLET') {
+    const branch = branchBore ?? 50;
+    const hit = brlenFromServiceOrConfigForOlet(headerBore, branch, cfg);
+    if (hit?.value != null) {
+      return {
+        brlen: hit.value,
+        source: hit.source,
+        complete: true,
+        diagnostics,
+      };
+    }
+    diagnostics.push({
+      severity: 'error',
+      code: 'BRLEN-OLET-MISSING',
+      message: 'OLET BRLEN unresolved: no direct BRLEN, no BP/CP geometry, and no weldolet table match.',
+      headerBore,
+      branchBore: branch,
+    });
+  } else {
+    diagnostics.push({
+      severity: 'info',
+      code: 'BRLEN-NOT-APPLICABLE',
+      message: `BRLEN fallback is not applicable to component type ${t || '(blank)'}.`,
+    });
+  }
+
+  return {
+    brlen: null,
+    source: 'unresolved',
+    complete: false,
+    diagnostics,
+  };
+}
+
+export function applyBrlenFallback(component, options = {}) {
+  const result = resolveBrlen(component, options);
+  return {
+    ...component,
+    brlen: result.brlen ?? component?.brlen ?? component?.branchLength ?? null,
+    brlenResolution: result,
+  };
+}
+
+export function resolveBrlenRows(rows = [], options = {}) {
+  const out = (Array.isArray(rows) ? rows : []).map(row => applyBrlenFallback(row, options));
+  return {
+    rows: out,
+    summary: {
+      inputRows: Array.isArray(rows) ? rows.length : 0,
+      resolved: out.filter(r => r.brlenResolution?.complete).length,
+      unresolved: out.filter(r => r.brlenResolution && !r.brlenResolution.complete && !['BRLEN-NOT-APPLICABLE'].includes(r.brlenResolution.diagnostics?.[0]?.code)).length,
+      direct: out.filter(r => r.brlenResolution?.source === 'direct-data-table').length,
+      geometry: out.filter(r => r.brlenResolution?.source === 'calculated-bp-minus-cp').length,
+      table: out.filter(r => /Service|rc-config/.test(r.brlenResolution?.source || '')).length,
+    }
+  };
+}
+
+try {
+  if (typeof window !== 'undefined') {
+    window.resolvePcfBrlen = resolveBrlen;
+    window.resolvePcfBrlenRows = resolveBrlenRows;
+  }
+} catch (_) {}

--- a/js/pcf-engine/calculated-columns.js
+++ b/js/pcf-engine/calculated-columns.js
@@ -1,0 +1,96 @@
+/**
+ * calculated-columns.js — Phase 4E calculated columns engine
+ *
+ * Adds deterministic calculated fields:
+ * - DIAMETER = BORE
+ * - WALL_THICK = CA4
+ * - BEND_PTR increments when to-component is BEND
+ * - RIGID_PTR increments when to-component is FLANGE or VALVE
+ * - INT_PTR increments when to-component is TEE or OLET
+ */
+
+function clean(value) {
+  return String(value ?? '').trim();
+}
+
+function n(value, fallback = null) {
+  if (value == null || value === '') return fallback;
+  const x = Number(value);
+  return Number.isFinite(x) ? x : fallback;
+}
+
+function typeOf(row) {
+  return clean(row?.type || row?.rawType || row?.Type).toUpperCase();
+}
+
+function ca4(row) {
+  return clean(row?.ca?.['4'] ?? row?.ca4 ?? row?.CA4 ?? row?.['CA4'] ?? row?.['CA 4']);
+}
+
+function bore(row) {
+  return n(row?.bore ?? row?.BORE ?? row?.Bore);
+}
+
+function targetType(row, rows, index) {
+  if (row?.toComponentType || row?.toType) return clean(row.toComponentType || row.toType).toUpperCase();
+  const next = rows?.[index + 1];
+  return typeOf(next);
+}
+
+export function applyCalculatedColumns(rows = [], options = {}) {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  let bendPtr = n(options.startBendPtr, 0) || 0;
+  let rigidPtr = n(options.startRigidPtr, 0) || 0;
+  let intPtr = n(options.startIntPtr, 0) || 0;
+
+  const out = safeRows.map((row, index) => {
+    const toType = targetType(row, safeRows, index);
+    if (toType === 'BEND') bendPtr += 1;
+    if (toType === 'FLANGE' || toType === 'VALVE') rigidPtr += 1;
+    if (toType === 'TEE' || toType === 'OLET') intPtr += 1;
+
+    const b = bore(row);
+    const wt = ca4(row);
+
+    return {
+      ...row,
+      diameter: row?.diameter ?? row?.DIAMETER ?? b,
+      wallThick: row?.wallThick ?? row?.WALL_THICK ?? wt,
+      bendPtr: row?.bendPtr ?? row?.BEND_PTR ?? bendPtr,
+      rigidPtr: row?.rigidPtr ?? row?.RIGID_PTR ?? rigidPtr,
+      intPtr: row?.intPtr ?? row?.INT_PTR ?? intPtr,
+      calculatedColumns: {
+        ...(row?.calculatedColumns || {}),
+        diameterSource: b != null ? 'BORE' : 'unresolved',
+        wallThickSource: wt ? 'CA4' : 'unresolved',
+        pointerRule: 'to-component-type',
+        toType,
+      }
+    };
+  });
+
+  return {
+    rows: out,
+    summary: {
+      inputRows: safeRows.length,
+      outputRows: out.length,
+      finalBendPtr: bendPtr,
+      finalRigidPtr: rigidPtr,
+      finalIntPtr: intPtr,
+      diameterResolved: out.filter(r => r.diameter != null && r.diameter !== '').length,
+      wallThickResolved: out.filter(r => clean(r.wallThick)).length,
+    }
+  };
+}
+
+export function applyCalculatedColumnsToRow(row, context = {}) {
+  const result = applyCalculatedColumns([row], context);
+  return result.rows[0];
+}
+
+try {
+  if (typeof window !== 'undefined') {
+    window.applyPcfCalculatedColumns = applyCalculatedColumns;
+    window.applyPcfCalculatedColumnsToRow = applyCalculatedColumnsToRow;
+  }
+} catch (_) {}

--- a/js/pcf-engine/certification-runner.js
+++ b/js/pcf-engine/certification-runner.js
@@ -1,0 +1,100 @@
+/**
+ * certification-runner.js — Phase 5F Common PCF certification runner
+ *
+ * Combines:
+ * - Common builder metadata/diff gate
+ * - SKEY validator
+ * - Formula validator
+ * - Fallback validator
+ * - ASME table certification
+ * - PCF output syntax validator
+ */
+
+import { evaluatePcfDiffGate } from './pcf-diff-gate.js';
+import { validateSkeyRows, validateSkeyInPcfText } from './validators/skey-validator.js';
+import { validateFormulaRows } from './validators/formula-validator.js';
+import { validateFallbackRows } from './validators/fallback-validator.js';
+import { validateAsmeCertification } from './validators/asme-table-validator.js';
+import { validatePcfOutputText } from './validators/pcf-output-validator.js';
+
+function errors(result){ return result?.summary?.errors ?? result?.gate?.summary?.errors ?? 0; }
+function passOf(result){ return result?.pass === true; }
+function countErrors(results){ return results.reduce((a,r)=>a+Number(errors(r)||0),0); }
+
+export function runCommonPcfCertification(input = {}, options = {}) {
+  const rows = input.rows || input.model?.blocks || [];
+  const pcfText = input.pcfText || input.commonText || input.meta?.commonText || '';
+  const diff = input.diff || null;
+  const meta = input.meta || {};
+
+  const gate = evaluatePcfDiffGate(diff, {
+    maxCritical: options.maxCritical ?? 0,
+    maxMajor: options.maxMajor ?? 0,
+    maxMinor: options.maxMinor ?? Infinity,
+    requireLegacyCommonDiff: options.requireLegacyCommonDiff !== false,
+    requireCommonBlocks: true,
+  });
+
+  const skeyRows = validateSkeyRows(rows, options.skey || {});
+  const skeyText = pcfText ? validateSkeyInPcfText(pcfText, options.skey || {}) : { pass:true, diagnostics:[], summary:{errors:0,warnings:0} };
+  const formulas = validateFormulaRows(rows, options.formula || {});
+  const fallbacks = validateFallbackRows(rows, options.fallback || {});
+  const asme = validateAsmeCertification(options.asme || {});
+  const output = pcfText ? validatePcfOutputText(pcfText, options.output || {}) : { pass:false, diagnostics:[{severity:'error',code:'CERT-NO-PCF-TEXT',message:'No Common PCF text supplied.'}], summary:{errors:1,warnings:0,blocks:0} };
+
+  const results = [skeyRows, skeyText, formulas, fallbacks, asme, output];
+  const validatorErrors = countErrors(results);
+  const commonPathOk = meta?.emittedBy === 'pcf-model-emitter' || input?.emitResult?.meta?.emittedBy === 'pcf-model-emitter';
+  const diagnosticsErrors = Number(meta?.diagnostics?.errors ?? 0);
+
+  const reasons = [];
+  if (!commonPathOk) reasons.push('Common path proof missing: expected emittedBy=pcf-model-emitter.');
+  if (diagnosticsErrors > 0) reasons.push(`Common diagnostics has ${diagnosticsErrors} errors.`);
+  if (!gate.pass) reasons.push(...gate.reasons.map(r => `Diff gate: ${r}`));
+  if (validatorErrors > 0) reasons.push(`Validators reported ${validatorErrors} errors.`);
+
+  const pass = reasons.length === 0;
+  return {
+    pass,
+    status: pass ? 'PASS' : 'FAIL',
+    reasons,
+    summary: {
+      commonPathOk,
+      diagnosticsErrors,
+      diffCritical: gate.summary.critical,
+      diffMajor: gate.summary.major,
+      diffMinor: gate.summary.minor,
+      validatorErrors,
+      skeyErrors: skeyRows.summary.errors + skeyText.summary.errors,
+      formulaErrors: formulas.summary.errors,
+      fallbackErrors: fallbacks.summary.errors,
+      asmeErrors: asme.summary.errors,
+      outputErrors: output.summary.errors,
+    },
+    sections: { gate, skeyRows, skeyText, formulas, fallbacks, asme, output },
+  };
+}
+
+export function runLastCommonPcfCertification(options = {}) {
+  const run = typeof window !== 'undefined' ? window.__COMMON_PCF_BUILDER_LAST_RUN__ : null;
+  if (!run) return { pass:false, status:'FAIL', reasons:['No __COMMON_PCF_BUILDER_LAST_RUN__ object found.'], summary:{ validatorErrors:1 }, sections:{} };
+  return runCommonPcfCertification({ rows: run.model?.blocks || [], pcfText: run.commonText || run.pcfText || '', diff: run.diff || null, meta: run.meta || {}, emitResult: run.emitResult || null }, options);
+}
+
+export function printLastCommonPcfCertification(options = {}) {
+  const result = runLastCommonPcfCertification(options);
+  if (typeof console !== 'undefined') {
+    console.log(`[Common PCF Certification] ${result.status}`, result.summary, result.reasons);
+    for (const [name, section] of Object.entries(result.sections || {})) {
+      const diags = section?.diagnostics || [];
+      if (diags.length) {
+        console.groupCollapsed(`${name}: ${diags.length} diagnostics`);
+        console.table(diags.slice(0, options.previewLimit ?? 50));
+        console.groupEnd();
+      }
+    }
+  }
+  return result;
+}
+
+try { if (typeof window !== 'undefined') { window.runCommonPcfCertification = runCommonPcfCertification; window.runLastCommonPcfCertification = runLastCommonPcfCertification; window.printLastCommonPcfCertification = printLastCommonPcfCertification; } } catch (_) {}

--- a/js/pcf-engine/column-alias-registry.js
+++ b/js/pcf-engine/column-alias-registry.js
@@ -1,0 +1,219 @@
+/**
+ * column-alias-registry.js — Phase 4A Smart Parser foundation
+ *
+ * Canonical column registry + fuzzy header matcher.
+ *
+ * This module is intentionally standalone so it can be used by:
+ * - future Smart Parser import path
+ * - browser diagnostics
+ * - benchmark/fixture tests
+ *
+ * Matching order:
+ *  1. exact normalized alias
+ *  2. substring containment
+ *  3. fuzzy ratio >= threshold
+ */
+
+export const CANONICAL_COLUMNS = Object.freeze({
+  ROW: '#',
+  CSV_SEQ_NO: 'CSV SEQ NO',
+  TYPE: 'Type',
+  TEXT: 'TEXT',
+  PIPELINE_REFERENCE: 'PIPELINE-REFERENCE',
+  REF_NO: 'REF NO.',
+  BORE: 'BORE',
+  BRANCH_BORE: 'BRANCH BORE',
+  EP1_COORDS: 'EP1 COORDS',
+  EP2_COORDS: 'EP2 COORDS',
+  CP_COORDS: 'CP COORDS',
+  BP_COORDS: 'BP COORDS',
+  SKEY: 'SKEY',
+  SUPPORT_COOR: 'SUPPORT COOR',
+  SUPPORT_GUID: 'SUPPORT GUID',
+  SUPPORT_NAME: 'SUPPORT NAME',
+  CA1: 'CA1',
+  CA2: 'CA2',
+  CA3: 'CA3',
+  CA4: 'CA4',
+  CA5: 'CA5',
+  CA6: 'CA6',
+  CA7: 'CA7',
+  CA8: 'CA8',
+  CA9: 'CA9',
+  CA10: 'CA10',
+  CA97: 'CA97',
+  CA98: 'CA98',
+  FIXING_ACTION: 'Fixing Action',
+  LEN1: 'LEN 1',
+  AXIS1: 'AXIS 1',
+  LEN2: 'LEN 2',
+  AXIS2: 'AXIS 2',
+  LEN3: 'LEN 3',
+  AXIS3: 'AXIS 3',
+  BRLEN: 'BRLEN',
+  DELTA_X: 'DELTA_X',
+  DELTA_Y: 'DELTA_Y',
+  DELTA_Z: 'DELTA_Z',
+  DIAMETER: 'DIAMETER',
+  WALL_THICK: 'WALL_THICK',
+  BEND_PTR: 'BEND_PTR',
+  RIGID_PTR: 'RIGID_PTR',
+  INT_PTR: 'INT_PTR',
+});
+
+export const DEFAULT_COLUMN_ALIASES = Object.freeze({
+  '#': ['#', 'Row', 'Row No', 'RowNo', 'Row Number', 'SN', 'S.N.', 'S.No', 'S No'],
+  'CSV SEQ NO': ['CSV SEQ NO', 'SEQ NO', 'Seq No', 'SL.NO', 'Sl No', 'SL NO', 'SeqNo', 'Seq', 'Sequence', 'Sequence No', 'Item No'],
+  'Type': ['Type', 'Component', 'Comp Type', 'CompType', 'Component Type', 'Fitting', 'Item'],
+  'TEXT': ['TEXT', 'Text', 'Description', 'Desc', 'Comment', 'MSG'],
+  'PIPELINE-REFERENCE': ['PIPELINE-REFERENCE', 'Pipeline Ref', 'Pipeline Reference', 'Line No', 'Line Number', 'Line No.', 'LineNo', 'PIPE', 'Pipe Line'],
+  'REF NO.': ['REF NO.', 'Ref No', 'RefNo', 'Reference No', 'Reference Number', 'Ref', 'Tag No', 'TagNo'],
+  'BORE': ['BORE', 'Bore', 'NPS', 'Nominal Bore', 'NominalBore', 'Dia', 'Diameter', 'Size', 'Pipe Size', 'DN', 'NB'],
+  'BRANCH BORE': ['BRANCH BORE', 'Branch Bore', 'BranchBore', 'Branch NPS', 'Branch DN', 'Branch Size', 'Bore Branch'],
+  'EP1 COORDS': ['EP1 COORDS', 'EP1', 'Start Point', 'From', 'From Coord', 'Start Coord', 'EP1_X EP1_Y EP1_Z', 'EP1 X Y Z'],
+  'EP2 COORDS': ['EP2 COORDS', 'EP2', 'End Point', 'To', 'To Coord', 'End Coord', 'EP2_X EP2_Y EP2_Z', 'EP2 X Y Z'],
+  'CP COORDS': ['CP COORDS', 'CP', 'Centre Point', 'Center Point', 'Centre', 'Center', 'CenterPt', 'CentrePt'],
+  'BP COORDS': ['BP COORDS', 'BP', 'Branch Point', 'Branch1 Point', 'Branch1', 'BranchPt', 'Branch'],
+  'SKEY': ['SKEY', 'Skey', 'S-Key', 'Component Key', 'Fitting Key'],
+  'SUPPORT COOR': ['SUPPORT COOR', 'Support Coord', 'Support Coords', 'Support Point', 'Restraint Coord', 'RestPt'],
+  'SUPPORT GUID': ['SUPPORT GUID', 'Support GUID', 'GUID', 'Node Name', 'NodeName', 'UCI'],
+  'SUPPORT NAME': ['SUPPORT NAME', 'Support Name', 'Support Type', 'Restraint Name', 'SupportCode'],
+  'CA1': ['CA1', 'CA 1', 'Attr1', 'Attribute 1', 'Attribute1', 'COMPONENT-ATTRIBUTE1'],
+  'CA2': ['CA2', 'CA 2', 'Attr2', 'Attribute 2', 'Attribute2', 'COMPONENT-ATTRIBUTE2'],
+  'CA3': ['CA3', 'CA 3', 'Attr3', 'Attribute 3', 'Attribute3', 'COMPONENT-ATTRIBUTE3', 'Material', 'Material Name'],
+  'CA4': ['CA4', 'CA 4', 'Attr4', 'Attribute 4', 'Attribute4', 'COMPONENT-ATTRIBUTE4', 'Wall Thickness', 'Wall Thick', 'WT', 'Thk'],
+  'CA5': ['CA5', 'CA 5', 'Attr5', 'Attribute 5', 'Attribute5', 'COMPONENT-ATTRIBUTE5'],
+  'CA6': ['CA6', 'CA 6', 'Attr6', 'Attribute 6', 'Attribute6', 'COMPONENT-ATTRIBUTE6'],
+  'CA7': ['CA7', 'CA 7', 'Attr7', 'Attribute 7', 'Attribute7', 'COMPONENT-ATTRIBUTE7', 'Corrosion Allowance', 'Corr Allow'],
+  'CA8': ['CA8', 'CA 8', 'Attr8', 'Attribute 8', 'Attribute8', 'COMPONENT-ATTRIBUTE8', 'Weight'],
+  'CA9': ['CA9', 'CA 9', 'Attr9', 'Attribute 9', 'Attribute9', 'COMPONENT-ATTRIBUTE9'],
+  'CA10': ['CA10', 'CA 10', 'Attr10', 'Attribute 10', 'Attribute10', 'COMPONENT-ATTRIBUTE10'],
+  'CA97': ['CA97', 'CA 97', 'Ref No Attr', 'RefAttr', 'COMPONENT-ATTRIBUTE97'],
+  'CA98': ['CA98', 'CA 98', 'Seq No Attr', 'SeqAttr', 'COMPONENT-ATTRIBUTE98'],
+  'Fixing Action': ['Fixing Action', 'Fix', 'Action', 'FixAction', 'Overlap', 'Gap Fill'],
+  'LEN 1': ['LEN 1', 'Len1', 'Length X', 'LenX', 'Dx', 'DX', 'Delta X', 'DeltaX'],
+  'AXIS 1': ['AXIS 1', 'Axis1', 'Dir X', 'DirX', 'Direction X'],
+  'LEN 2': ['LEN 2', 'Len2', 'Length Y', 'LenY', 'Dy', 'DY', 'Delta Y', 'DeltaY'],
+  'AXIS 2': ['AXIS 2', 'Axis2', 'Dir Y', 'DirY', 'Direction Y'],
+  'LEN 3': ['LEN 3', 'Len3', 'Length Z', 'LenZ', 'Dz', 'DZ', 'Delta Z', 'DeltaZ'],
+  'AXIS 3': ['AXIS 3', 'Axis3', 'Dir Z', 'DirZ', 'Direction Z'],
+  'BRLEN': ['BRLEN', 'BrLen', 'Branch Length', 'Branch Len', 'Br Len'],
+  'DELTA_X': ['DELTA_X', 'DeltaX', 'Delta X', 'Dx', 'dX'],
+  'DELTA_Y': ['DELTA_Y', 'DeltaY', 'Delta Y', 'Dy', 'dY'],
+  'DELTA_Z': ['DELTA_Z', 'DeltaZ', 'Delta Z', 'Dz', 'dZ'],
+  'DIAMETER': ['DIAMETER', 'Dia', 'OD', 'O/D', 'Outer Diameter', 'Outside Diameter'],
+  'WALL_THICK': ['WALL_THICK', 'Wall Thick', 'WT', 'Wall Thickness', 'Thk', 'Thickness'],
+  'BEND_PTR': ['BEND_PTR', 'Bend Ptr', 'BendPointer'],
+  'RIGID_PTR': ['RIGID_PTR', 'Rigid Ptr', 'RigidPointer'],
+  'INT_PTR': ['INT_PTR', 'Intersection Ptr', 'IntersectionPointer', 'Int Ptr'],
+});
+
+export function normalizeHeaderText(text) {
+  return String(text ?? '').toLowerCase().trim().replace(/[^a-z0-9]/g, '');
+}
+
+function similarity(a, b) {
+  const s1 = normalizeHeaderText(a);
+  const s2 = normalizeHeaderText(b);
+  if (!s1 && !s2) return 1;
+  if (!s1 || !s2) return 0;
+
+  const rows = s1.length + 1;
+  const cols = s2.length + 1;
+  const dp = Array.from({ length: rows }, () => Array(cols).fill(0));
+  for (let i = 0; i < rows; i++) dp[i][0] = i;
+  for (let j = 0; j < cols; j++) dp[0][j] = j;
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      const cost = s1[i - 1] === s2[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost);
+    }
+  }
+  const dist = dp[s1.length][s2.length];
+  return 1 - dist / Math.max(s1.length, s2.length);
+}
+
+export function buildAliasRegistry(customAliases = {}) {
+  const merged = {};
+  for (const [canonical, aliases] of Object.entries(DEFAULT_COLUMN_ALIASES)) {
+    merged[canonical] = [...aliases];
+  }
+  for (const [canonical, aliases] of Object.entries(customAliases || {})) {
+    merged[canonical] = [...(merged[canonical] || []), ...(Array.isArray(aliases) ? aliases : [aliases])].filter(Boolean);
+  }
+  return merged;
+}
+
+export function fuzzyMatchHeader(headerText, aliasConfig = DEFAULT_COLUMN_ALIASES, options = {}) {
+  const threshold = Number(options.threshold ?? 0.75);
+  const normHeader = normalizeHeaderText(headerText);
+  if (!normHeader) return null;
+
+  // Pass 1: exact match on normalized aliases/canonical names.
+  for (const [canonical, aliases] of Object.entries(aliasConfig || {})) {
+    const candidates = [canonical, ...(aliases || [])];
+    for (const alias of candidates) {
+      if (normalizeHeaderText(alias) === normHeader) {
+        return { canonical, score: 1, method: 'exact', alias };
+      }
+    }
+  }
+
+  // Pass 2: substring containment, but avoid too-short accidental matches.
+  for (const [canonical, aliases] of Object.entries(aliasConfig || {})) {
+    const candidates = [canonical, ...(aliases || [])];
+    for (const alias of candidates) {
+      const normAlias = normalizeHeaderText(alias);
+      if (normAlias.length < 3 || normHeader.length < 3) continue;
+      if (normAlias.includes(normHeader) || normHeader.includes(normAlias)) {
+        return { canonical, score: 0.9, method: 'contains', alias };
+      }
+    }
+  }
+
+  // Pass 3: fuzzy edit similarity.
+  let best = null;
+  for (const [canonical, aliases] of Object.entries(aliasConfig || {})) {
+    const candidates = [canonical, ...(aliases || [])];
+    for (const alias of candidates) {
+      const score = similarity(normHeader, alias);
+      if (score >= threshold && (!best || score > best.score)) {
+        best = { canonical, score, method: 'fuzzy', alias };
+      }
+    }
+  }
+  return best;
+}
+
+export function mapHeaders(headers = [], options = {}) {
+  const aliasConfig = buildAliasRegistry(options.customAliases || {});
+  const out = {};
+  const diagnostics = [];
+  for (const header of headers || []) {
+    const match = fuzzyMatchHeader(header, aliasConfig, options);
+    if (!match) {
+      diagnostics.push({ severity: 'info', header, message: 'Header not matched to canonical column' });
+      continue;
+    }
+    if (!out[match.canonical]) {
+      out[match.canonical] = header;
+    } else {
+      diagnostics.push({
+        severity: 'warning',
+        header,
+        canonical: match.canonical,
+        existing: out[match.canonical],
+        message: 'Multiple source headers matched one canonical column; keeping first match',
+      });
+    }
+  }
+  return { map: out, diagnostics };
+}
+
+try {
+  if (typeof window !== 'undefined') {
+    window.PCF_COLUMN_ALIASES = DEFAULT_COLUMN_ALIASES;
+    window.mapPcfHeaders = mapHeaders;
+    window.fuzzyMatchPcfHeader = fuzzyMatchHeader;
+  }
+} catch (_) {}

--- a/js/pcf-engine/common-pcf-builder.js
+++ b/js/pcf-engine/common-pcf-builder.js
@@ -1,12 +1,9 @@
 /**
- * common-pcf-builder.js — Phase 1 Common PCF Builder
+ * common-pcf-builder.js — Common PCF Builder
  *
  * Purpose:
- *   Create a real, callable Common PCF Builder path without deleting or rewriting
- *   the legacy Stage 4 emitter. Phase 1 deliberately delegates final text emission
- *   to the existing legacy emitter after building a canonical model and running
- *   common-engine diagnostics. This proves the common path is active and gives the
- *   project a stable boundary for Phase 2/3 replacement of individual block emitters.
+ *   Build a canonical model, run common diagnostics, emit PCF using the Common
+ *   model emitter, and optionally diff against legacy output.
  *
  * Contract:
  *   buildCommonPcf({ components, injectedPipes, pipelineRef, cfg, logFn, legacyEmitter })
@@ -14,43 +11,16 @@
  */
 
 import { runSyntaxCheck } from './syntax-checker.js';
+import { emitPcfModel } from './pcf-model-emitter.js';
+import { diffPcfOutputs } from './pcf-output-diff.js';
 
-const COMMON_BUILDER_VERSION = 'phase1.0.0';
+const COMMON_BUILDER_VERSION = 'phase2.0.0';
 
-const EMIT_TYPES = new Set([
-  'PIPE',
-  'FLANGE',
-  'FBLI',
-  'BEND',
-  'TEE',
-  'OLET',
-  'VALVE',
-  'REDU',
-  'REDUCER-CONCENTRIC',
-  'REDUCER-ECCENTRIC',
-  'SUPPORT'
-]);
-
+const EMIT_TYPES = new Set(['PIPE','FLANGE','FBLI','BEND','TEE','OLET','VALVE','REDU','REDUCER-CONCENTRIC','REDUCER-ECCENTRIC','SUPPORT']);
 const SKIP_TYPES = new Set(['GASK', 'PCOM', 'MISC', 'WELD', 'ATTA', 'INST']);
-
-function n(v, fallback = 0) {
-  const x = Number(v);
-  return Number.isFinite(x) ? x : fallback;
-}
-
-function cleanText(v) {
-  return String(v ?? '').replace(/=/g, '').trim();
-}
-
-function clonePoint(pt) {
-  if (!pt || typeof pt !== 'object') return null;
-  const x = n(pt.x, NaN);
-  const y = n(pt.y, NaN);
-  const z = n(pt.z, NaN);
-  if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) return null;
-  return { x, y, z };
-}
-
+function n(v, fallback = 0) { const x = Number(v); return Number.isFinite(x) ? x : fallback; }
+function cleanText(v) { return String(v ?? '').replace(/=/g, '').trim(); }
+function clonePoint(pt) { if (!pt || typeof pt !== 'object') return null; const x = n(pt.x, NaN), y = n(pt.y, NaN), z = n(pt.z, NaN); return Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z) ? { x, y, z } : null; }
 function buildCa(comp) {
   const ca = {};
   for (let i = 1; i <= 10; i++) {
@@ -59,271 +29,83 @@ function buildCa(comp) {
     const val = direct ?? nested;
     if (val != null && val !== '') ca[String(i)] = String(val).trim();
   }
-  if (comp?.weight != null && comp.weight !== '' && (ca['8'] == null || ca['8'] === '')) {
-    ca['8'] = String(comp.weight).trim();
-  }
+  if (comp?.weight != null && comp.weight !== '' && (ca['8'] == null || ca['8'] === '')) ca['8'] = String(comp.weight).trim();
   return ca;
 }
-
-function normalizeType(type) {
-  const t = String(type || '').trim().toUpperCase();
-  if (t === 'REDU') return 'REDUCER-CONCENTRIC';
-  if (t === 'FBLI') return 'FLANGE';
-  return t;
-}
-
-function blockTypeForDiagnostics(comp) {
-  return normalizeType(comp?.type);
-}
-
+function normalizeType(type) { const t = String(type || '').trim().toUpperCase(); if (t === 'REDU') return 'REDUCER-CONCENTRIC'; if (t === 'FBLI') return 'FLANGE'; return t; }
+function blockTypeForDiagnostics(comp) { return normalizeType(comp?.type); }
 function normalizeComponent(comp, sourceKind = 'component', index = 0) {
   const rawType = String(comp?.type || '').trim().toUpperCase();
   const type = normalizeType(rawType);
   const ca = buildCa(comp || {});
   const refNo = cleanText(comp?.ca97 || comp?.refNo || comp?.fromRefNo || '');
   const seqNo = comp?.seqNo ?? index + 1;
-
   return {
     id: `${sourceKind}:${refNo || rawType || 'UNKNOWN'}:${index + 1}`,
-    sourceKind,
-    rawType,
-    type,
+    sourceKind, rawType, type,
     emitEligible: EMIT_TYPES.has(rawType) || EMIT_TYPES.has(type),
     skipReason: SKIP_TYPES.has(rawType) ? 'non-fitting passthrough' : '',
-    refNo,
-    seqNo,
+    refNo, seqNo,
     bore: n(comp?.bore, 0),
     branchBore: comp?.branchBore == null || comp.branchBore === '' ? null : n(comp.branchBore, 0),
-    ep1: clonePoint(comp?.ep1),
-    ep2: clonePoint(comp?.ep2),
-    cp: clonePoint(comp?.cp),
-    bp: clonePoint(comp?.bp),
+    ep1: clonePoint(comp?.ep1), ep2: clonePoint(comp?.ep2), cp: clonePoint(comp?.cp), bp: clonePoint(comp?.bp),
     supportCoor: clonePoint(comp?.supportCoor || comp?.supportCoord || comp?.cp),
     skey: cleanText(comp?.skey || ''),
     supportName: cleanText(comp?.supportName || ''),
     supportGuid: cleanText(comp?.supportGuid || ''),
     angleDeg: comp?.angleDeg ?? (rawType === 'BEND' || type === 'BEND' ? 90 : null),
     radius: comp?.radius ?? comp?.bendRadius ?? null,
+    brlen: comp?.brlen ?? comp?.branchLength ?? '',
+    weight: comp?.weight ?? comp?.directWeight ?? '',
     ca,
-    source: {
-      originalRefNo: cleanText(comp?.refNo || ''),
-      ca97: cleanText(comp?.ca97 || ''),
-      fromRefNo: cleanText(comp?.fromRefNo || ''),
-      toRefNo: cleanText(comp?.toRefNo || ''),
-    }
+    source: { originalRefNo: cleanText(comp?.refNo || ''), ca97: cleanText(comp?.ca97 || ''), fromRefNo: cleanText(comp?.fromRefNo || ''), toRefNo: cleanText(comp?.toRefNo || '') }
   };
 }
-
-function countByType(blocks) {
-  const out = {};
-  for (const b of blocks) out[b.type] = (out[b.type] || 0) + 1;
-  return out;
-}
-
+function countByType(blocks) { const out = {}; for (const b of blocks) out[b.type] = (out[b.type] || 0) + 1; return out; }
 function makeModel({ components = [], injectedPipes = [], pipelineRef = '', cfg = {} }) {
-  const componentBlocks = (Array.isArray(components) ? components : [])
-    .map((c, i) => normalizeComponent(c, 'component', i));
-  const bridgeBlocks = (Array.isArray(injectedPipes) ? injectedPipes : [])
-    .map((c, i) => normalizeComponent({ ...c, type: 'PIPE' }, 'bridge', i));
-
-  return {
-    engine: 'common',
-    version: COMMON_BUILDER_VERSION,
-    pipelineRef: cleanText(pipelineRef),
-    cfgSnapshot: {
-      decimalPrecision: cfg?.decimalPrecision,
-      windowsLineEndings: cfg?.windowsLineEndings,
-      maxEpCoordValue: cfg?.maxEpCoordValue,
-      supportDefaultCoor: cfg?.supportDefaultCoor,
-    },
-    blocks: [...componentBlocks, ...bridgeBlocks],
-    componentBlocks,
-    bridgeBlocks,
-    summary: {
-      inputComponents: componentBlocks.length,
-      injectedPipes: bridgeBlocks.length,
-      emitEligible: [...componentBlocks, ...bridgeBlocks].filter(b => b.emitEligible).length,
-      skipped: [...componentBlocks, ...bridgeBlocks].filter(b => b.skipReason).length,
-      byType: countByType([...componentBlocks, ...bridgeBlocks]),
-    }
-  };
+  const componentBlocks = (Array.isArray(components) ? components : []).map((c, i) => normalizeComponent(c, 'component', i));
+  const bridgeBlocks = (Array.isArray(injectedPipes) ? injectedPipes : []).map((c, i) => normalizeComponent({ ...c, type: 'PIPE' }, 'bridge', i));
+  const blocks = [...componentBlocks, ...bridgeBlocks];
+  return { engine: 'common', version: COMMON_BUILDER_VERSION, pipelineRef: cleanText(pipelineRef), cfgSnapshot: { decimalPrecision: cfg?.decimalPrecision, windowsLineEndings: cfg?.windowsLineEndings, maxEpCoordValue: cfg?.maxEpCoordValue, supportDefaultCoor: cfg?.supportDefaultCoor }, blocks, componentBlocks, bridgeBlocks, summary: { inputComponents: componentBlocks.length, injectedPipes: bridgeBlocks.length, emitEligible: blocks.filter(b => b.emitEligible).length, skipped: blocks.filter(b => b.skipReason).length, byType: countByType(blocks) } };
 }
-
 function preflightModel(model) {
-  const errors = [];
-  const warnings = [];
-  const infos = [];
-
-  if (!model.pipelineRef) {
-    warnings.push({
-      id: 'CB-001',
-      severity: 'WARNING',
-      type: 'HEADER',
-      message: 'PIPELINE-REFERENCE is blank',
-      detail: 'Common builder received an empty pipelineRef',
-      fixHint: 'Run Pipeline Ref lookup or ensure Stage 1 derives PIPELINE-REFERENCE'
-    });
-  }
-
+  const errors = [], warnings = [], infos = [];
+  if (!model.pipelineRef) warnings.push({ id: 'CB-001', severity: 'WARNING', type: 'HEADER', message: 'PIPELINE-REFERENCE is blank', detail: 'Common builder received an empty pipelineRef', fixHint: 'Run Pipeline Ref lookup or ensure Stage 1 derives PIPELINE-REFERENCE' });
   for (const block of model.blocks) {
-    if (block.skipReason) {
-      infos.push({
-        id: 'CB-010',
-        severity: 'INFO',
-        type: block.type,
-        message: `${block.rawType} skipped from PCF emission`,
-        detail: block.skipReason,
-        fixHint: ''
-      });
-      continue;
-    }
-
-    if (!block.emitEligible) {
-      warnings.push({
-        id: 'CB-011',
-        severity: 'WARNING',
-        type: block.rawType || block.type,
-        message: `Unknown component type: ${block.rawType || block.type}`,
-        detail: `RefNo: ${block.refNo || '?'}`,
-        fixHint: 'Add the type to Common Builder mapping or upstream typeMap'
-      });
-    }
-
-    if (['PIPE', 'FLANGE', 'VALVE', 'REDUCER-CONCENTRIC', 'REDUCER-ECCENTRIC'].includes(block.type)) {
-      if (!block.ep1 || !block.ep2) {
-        errors.push({
-          id: 'CB-020',
-          severity: 'ERROR',
-          type: block.type,
-          message: `${block.type} missing END-POINT geometry`,
-          detail: `RefNo: ${block.refNo || '?'}`,
-          fixHint: 'Check EP1/EP2 in Stage 1/Stage 3 before emitting PCF'
-        });
-      }
-    }
-
-    if (block.type === 'BEND' && (!block.ep1 || !block.ep2 || !block.cp)) {
-      errors.push({
-        id: 'CB-021',
-        severity: 'ERROR',
-        type: 'BEND',
-        message: 'BEND missing EP1/EP2/CP geometry',
-        detail: `RefNo: ${block.refNo || '?'}`,
-        fixHint: 'BEND requires two END-POINTs and one CENTRE-POINT'
-      });
-    }
-
-    if (block.type === 'TEE' && (!block.ep1 || !block.ep2 || !block.cp || !block.bp)) {
-      errors.push({
-        id: 'CB-022',
-        severity: 'ERROR',
-        type: 'TEE',
-        message: 'TEE missing EP1/EP2/CP/BP geometry',
-        detail: `RefNo: ${block.refNo || '?'}`,
-        fixHint: 'TEE requires END-POINTs, CENTRE-POINT and BRANCH1-POINT'
-      });
-    }
-
-    if (block.type === 'OLET' && (!block.cp || !block.bp)) {
-      errors.push({
-        id: 'CB-023',
-        severity: 'ERROR',
-        type: 'OLET',
-        message: 'OLET missing CP/BP geometry',
-        detail: `RefNo: ${block.refNo || '?'}`,
-        fixHint: 'OLET requires CENTRE-POINT and BRANCH1-POINT'
-      });
-    }
+    if (block.skipReason) { infos.push({ id: 'CB-010', severity: 'INFO', type: block.type, message: `${block.rawType} skipped from PCF emission`, detail: block.skipReason, fixHint: '' }); continue; }
+    if (!block.emitEligible) warnings.push({ id: 'CB-011', severity: 'WARNING', type: block.rawType || block.type, message: `Unknown component type: ${block.rawType || block.type}`, detail: `RefNo: ${block.refNo || '?'}`, fixHint: 'Add the type to Common Builder mapping or upstream typeMap' });
+    if (['PIPE','FLANGE','VALVE','REDUCER-CONCENTRIC','REDUCER-ECCENTRIC'].includes(block.type) && (!block.ep1 || !block.ep2)) errors.push({ id: 'CB-020', severity: 'ERROR', type: block.type, message: `${block.type} missing END-POINT geometry`, detail: `RefNo: ${block.refNo || '?'}`, fixHint: 'Check EP1/EP2 in Stage 1/Stage 3 before emitting PCF' });
+    if (block.type === 'BEND' && (!block.ep1 || !block.ep2 || !block.cp)) errors.push({ id: 'CB-021', severity: 'ERROR', type: 'BEND', message: 'BEND missing EP1/EP2/CP geometry', detail: `RefNo: ${block.refNo || '?'}`, fixHint: 'BEND requires two END-POINTs and one CENTRE-POINT' });
+    if (block.type === 'TEE' && (!block.ep1 || !block.ep2 || !block.cp || !block.bp)) errors.push({ id: 'CB-022', severity: 'ERROR', type: 'TEE', message: 'TEE missing EP1/EP2/CP/BP geometry', detail: `RefNo: ${block.refNo || '?'}`, fixHint: 'TEE requires END-POINTs, CENTRE-POINT and BRANCH1-POINT' });
+    if (block.type === 'OLET' && (!block.cp || !block.bp)) errors.push({ id: 'CB-023', severity: 'ERROR', type: 'OLET', message: 'OLET missing CP/BP geometry', detail: `RefNo: ${block.refNo || '?'}`, fixHint: 'OLET requires CENTRE-POINT and BRANCH1-POINT' });
   }
-
   return { errors, warnings, infos };
 }
-
-function checkerComponents(model) {
-  return model.blocks
-    .filter(b => !b.skipReason && b.emitEligible)
-    .map(b => ({
-      ...b,
-      type: blockTypeForDiagnostics(b),
-      ca: b.ca,
-      refNo: b.refNo,
-      seqNo: b.seqNo,
-    }));
-}
-
-function mergeDiagnostics(preflight, syntax) {
-  return {
-    errors: [...(preflight.errors || []), ...(syntax.errors || [])],
-    warnings: [...(preflight.warnings || []), ...(syntax.warnings || [])],
-    infos: [...(preflight.infos || []), ...(syntax.infos || [])],
-  };
-}
-
-export function buildCommonPcf({
-  components = [],
-  injectedPipes = [],
-  pipelineRef = '',
-  cfg = {},
-  logFn = () => {},
-  legacyEmitter = null,
-} = {}) {
+function checkerComponents(model) { return model.blocks.filter(b => !b.skipReason && b.emitEligible).map(b => ({ ...b, type: blockTypeForDiagnostics(b), ca: b.ca, refNo: b.refNo, seqNo: b.seqNo })); }
+function mergeDiagnostics(preflight, syntax) { return { errors: [...(preflight.errors || []), ...(syntax.errors || [])], warnings: [...(preflight.warnings || []), ...(syntax.warnings || [])], infos: [...(preflight.infos || []), ...(syntax.infos || [])] }; }
+export function buildCommonPcf({ components = [], injectedPipes = [], pipelineRef = '', cfg = {}, logFn = () => {}, legacyEmitter = null } = {}) {
   const startedAt = Date.now();
   const model = makeModel({ components, injectedPipes, pipelineRef, cfg });
   const preflight = preflightModel(model);
   const syntax = runSyntaxCheck(checkerComponents(model), cfg);
   const diagnostics = mergeDiagnostics(preflight, syntax);
-
-  logFn('S4', 'common-builder-model-built', '', {
-    version: COMMON_BUILDER_VERSION,
-    blocks: model.blocks.length,
-    components: model.summary.inputComponents,
-    bridges: model.summary.injectedPipes,
-    errors: diagnostics.errors.length,
-    warnings: diagnostics.warnings.length,
-    infos: diagnostics.infos.length,
-  });
-
-  if (typeof legacyEmitter !== 'function') {
-    throw new Error('Common PCF Builder Phase 1 requires a legacyEmitter callback for text emission.');
+  logFn('S4', 'common-builder-model-built', '', { version: COMMON_BUILDER_VERSION, blocks: model.blocks.length, components: model.summary.inputComponents, bridges: model.summary.injectedPipes, errors: diagnostics.errors.length, warnings: diagnostics.warnings.length, infos: diagnostics.infos.length });
+  const emitResult = emitPcfModel(model, cfg);
+  const pcfText = emitResult.pcfText || '';
+  let legacyText = '';
+  let diff = null;
+  if (typeof legacyEmitter === 'function' && cfg?.commonBuilderRunLegacyDiff !== false) {
+    try {
+      const legacyResult = legacyEmitter(components, injectedPipes, pipelineRef, logFn);
+      legacyText = legacyResult?.pcfText || '';
+      diff = diffPcfOutputs(legacyText, pcfText, { coordTolerance: cfg?.commonBuilderDiffTolerance ?? 0.001 });
+    } catch (err) {
+      diff = { pass: false, summary: { legacyBlockCount: 0, commonBlockCount: emitResult.meta.blockCount, total: 1, critical: 1, major: 0, minor: 0 }, diffs: [{ severity: 'critical', path: 'legacyEmitter', legacy: '', common: '', message: err?.message || String(err) }] };
+    }
   }
-
-  // Phase 1: legacy text emission is intentionally delegated after Common model
-  // normalization/diagnostics. Phase 2 replaces this with emitPcfModel(model, cfg).
-  const legacyResult = legacyEmitter(components, injectedPipes, pipelineRef, logFn);
-  const pcfText = legacyResult?.pcfText || '';
-
-  const meta = {
-    engine: 'common',
-    phase: 'phase1-delegates-to-legacy-emitter',
-    builderVersion: COMMON_BUILDER_VERSION,
-    emittedBy: 'legacy-emitter-delegate',
-    startedAt,
-    finishedAt: Date.now(),
-    lineCount: pcfText ? pcfText.split(/\r?\n/).length : 0,
-    diagnostics: {
-      errors: diagnostics.errors.length,
-      warnings: diagnostics.warnings.length,
-      infos: diagnostics.infos.length,
-    },
-    summary: model.summary,
-  };
-
-  try {
-    window.__COMMON_PCF_BUILDER_LAST_RUN__ = { meta, model, diagnostics };
-  } catch (_) {
-    // non-browser execution
-  }
-
+  const meta = { engine: 'common', phase: 'phase2-common-model-emitter', builderVersion: COMMON_BUILDER_VERSION, emittedBy: 'pcf-model-emitter', startedAt, finishedAt: Date.now(), lineCount: pcfText ? pcfText.split(/\r?\n/).length : 0, blockCount: emitResult.meta.blockCount, diagnostics: { errors: diagnostics.errors.length, warnings: diagnostics.warnings.length, infos: diagnostics.infos.length }, diffSummary: diff?.summary || null, diffPass: diff?.pass ?? null, summary: model.summary };
+  try { window.__COMMON_PCF_BUILDER_LAST_RUN__ = { meta, model, diagnostics, legacyText, commonText: pcfText, diff }; } catch (_) {}
   logFn('S4', 'common-builder-emitted', '', meta);
-
-  return {
-    pcfText,
-    model,
-    diagnostics,
-    meta,
-  };
+  return { pcfText, model, diagnostics, emitResult, legacyText, diff, meta };
 }
-
-export function normalizeToPcfModel(args = {}) {
-  return makeModel(args);
-}
+export function normalizeToPcfModel(args = {}) { return makeModel(args); }

--- a/js/pcf-engine/common-pcf-builder.js
+++ b/js/pcf-engine/common-pcf-builder.js
@@ -3,7 +3,8 @@
  *
  * Purpose:
  *   Build a canonical model, run common diagnostics, emit PCF using the Common
- *   model emitter, and optionally diff against legacy output.
+ *   model emitter, optionally diff against legacy output, and evaluate the
+ *   Phase 3E production certification gate.
  *
  * Contract:
  *   buildCommonPcf({ components, injectedPipes, pipelineRef, cfg, logFn, legacyEmitter })
@@ -13,8 +14,9 @@
 import { runSyntaxCheck } from './syntax-checker.js';
 import { emitPcfModel } from './pcf-model-emitter.js';
 import { diffPcfOutputs } from './pcf-output-diff.js';
+import { evaluatePcfDiffGate } from './pcf-diff-gate.js';
 
-const COMMON_BUILDER_VERSION = 'phase2.0.0';
+const COMMON_BUILDER_VERSION = 'phase3.0.0';
 
 const EMIT_TYPES = new Set(['PIPE','FLANGE','FBLI','BEND','TEE','OLET','VALVE','REDU','REDUCER-CONCENTRIC','REDUCER-ECCENTRIC','SUPPORT']);
 const SKIP_TYPES = new Set(['GASK', 'PCOM', 'MISC', 'WELD', 'ATTA', 'INST']);
@@ -83,6 +85,15 @@ function preflightModel(model) {
 }
 function checkerComponents(model) { return model.blocks.filter(b => !b.skipReason && b.emitEligible).map(b => ({ ...b, type: blockTypeForDiagnostics(b), ca: b.ca, refNo: b.refNo, seqNo: b.seqNo })); }
 function mergeDiagnostics(preflight, syntax) { return { errors: [...(preflight.errors || []), ...(syntax.errors || [])], warnings: [...(preflight.warnings || []), ...(syntax.warnings || [])], infos: [...(preflight.infos || []), ...(syntax.infos || [])] }; }
+function gateOptionsFromConfig(cfg = {}) {
+  return {
+    maxCritical: cfg.commonBuilderGateMaxCritical ?? 0,
+    maxMajor: cfg.commonBuilderGateMaxMajor ?? 0,
+    maxMinor: cfg.commonBuilderGateMaxMinor ?? Infinity,
+    requireLegacyCommonDiff: cfg.commonBuilderRunLegacyDiff !== false,
+    requireCommonBlocks: true,
+  };
+}
 export function buildCommonPcf({ components = [], injectedPipes = [], pipelineRef = '', cfg = {}, logFn = () => {}, legacyEmitter = null } = {}) {
   const startedAt = Date.now();
   const model = makeModel({ components, injectedPipes, pipelineRef, cfg });
@@ -103,9 +114,11 @@ export function buildCommonPcf({ components = [], injectedPipes = [], pipelineRe
       diff = { pass: false, summary: { legacyBlockCount: 0, commonBlockCount: emitResult.meta.blockCount, total: 1, critical: 1, major: 0, minor: 0 }, diffs: [{ severity: 'critical', path: 'legacyEmitter', legacy: '', common: '', message: err?.message || String(err) }] };
     }
   }
-  const meta = { engine: 'common', phase: 'phase2-common-model-emitter', builderVersion: COMMON_BUILDER_VERSION, emittedBy: 'pcf-model-emitter', startedAt, finishedAt: Date.now(), lineCount: pcfText ? pcfText.split(/\r?\n/).length : 0, blockCount: emitResult.meta.blockCount, diagnostics: { errors: diagnostics.errors.length, warnings: diagnostics.warnings.length, infos: diagnostics.infos.length }, diffSummary: diff?.summary || null, diffPass: diff?.pass ?? null, summary: model.summary };
-  try { window.__COMMON_PCF_BUILDER_LAST_RUN__ = { meta, model, diagnostics, legacyText, commonText: pcfText, diff }; } catch (_) {}
+  const gate = evaluatePcfDiffGate(diff, gateOptionsFromConfig(cfg));
+  const meta = { engine: 'common', phase: 'phase3-common-model-emitter-gated', builderVersion: COMMON_BUILDER_VERSION, emittedBy: 'pcf-model-emitter', startedAt, finishedAt: Date.now(), lineCount: pcfText ? pcfText.split(/\r?\n/).length : 0, blockCount: emitResult.meta.blockCount, diagnostics: { errors: diagnostics.errors.length, warnings: diagnostics.warnings.length, infos: diagnostics.infos.length }, diffSummary: diff?.summary || null, diffPass: diff?.pass ?? null, gate, gatePass: gate.pass, gateStatus: gate.status, summary: model.summary };
+  try { window.__COMMON_PCF_BUILDER_LAST_RUN__ = { meta, model, diagnostics, legacyText, commonText: pcfText, diff, gate, emitResult }; } catch (_) {}
   logFn('S4', 'common-builder-emitted', '', meta);
-  return { pcfText, model, diagnostics, emitResult, legacyText, diff, meta };
+  logFn('S4', 'common-builder-gate', '', { status: gate.status, summary: gate.summary, reasons: gate.reasons });
+  return { pcfText, model, diagnostics, emitResult, legacyText, diff, gate, meta };
 }
 export function normalizeToPcfModel(args = {}) { return makeModel(args); }

--- a/js/pcf-engine/common-pcf-builder.js
+++ b/js/pcf-engine/common-pcf-builder.js
@@ -2,21 +2,22 @@
  * common-pcf-builder.js — Common PCF Builder
  *
  * Purpose:
- *   Build a canonical model, run common diagnostics, emit PCF using the Common
- *   model emitter, optionally diff against legacy output, and evaluate the
- *   Phase 3E production certification gate.
- *
- * Contract:
- *   buildCommonPcf({ components, injectedPipes, pipelineRef, cfg, logFn, legacyEmitter })
- *     -> { pcfText, model, diagnostics, meta }
+ *   Build a canonical model, run Phase 4 smart preprocessing, run common
+ *   diagnostics, emit PCF using the Common model emitter, optionally diff against
+ *   legacy output, and evaluate the certification gate.
  */
 
 import { runSyntaxCheck } from './syntax-checker.js';
 import { emitPcfModel } from './pcf-model-emitter.js';
 import { diffPcfOutputs } from './pcf-output-diff.js';
 import { evaluatePcfDiffGate } from './pcf-diff-gate.js';
+import { syncGeometryRows } from './geometry-sync.js';
+import { applyCpBpFallbacks } from './cp-bp-fallbacks.js';
+import { resolveBrlenRows } from './brlen-resolver.js';
+import { applyCalculatedColumns } from './calculated-columns.js';
+import { applySupportMappings } from './support-mapper.js';
 
-const COMMON_BUILDER_VERSION = 'phase3.0.0';
+const COMMON_BUILDER_VERSION = 'phase4g.0.0';
 
 const EMIT_TYPES = new Set(['PIPE','FLANGE','FBLI','BEND','TEE','OLET','VALVE','REDU','REDUCER-CONCENTRIC','REDUCER-ECCENTRIC','SUPPORT']);
 const SKIP_TYPES = new Set(['GASK', 'PCOM', 'MISC', 'WELD', 'ATTA', 'INST']);
@@ -43,11 +44,13 @@ function normalizeComponent(comp, sourceKind = 'component', index = 0) {
   const refNo = cleanText(comp?.ca97 || comp?.refNo || comp?.fromRefNo || '');
   const seqNo = comp?.seqNo ?? index + 1;
   return {
-    id: `${sourceKind}:${refNo || rawType || 'UNKNOWN'}:${index + 1}`,
+    ...comp,
+    id: comp?.id || `${sourceKind}:${refNo || rawType || 'UNKNOWN'}:${index + 1}`,
     sourceKind, rawType, type,
     emitEligible: EMIT_TYPES.has(rawType) || EMIT_TYPES.has(type),
     skipReason: SKIP_TYPES.has(rawType) ? 'non-fitting passthrough' : '',
     refNo, seqNo,
+    csvSeqNo: comp?.csvSeqNo ?? comp?.seqNo ?? seqNo,
     bore: n(comp?.bore, 0),
     branchBore: comp?.branchBore == null || comp.branchBore === '' ? null : n(comp.branchBore, 0),
     ep1: clonePoint(comp?.ep1), ep2: clonePoint(comp?.ep2), cp: clonePoint(comp?.cp), bp: clonePoint(comp?.bp),
@@ -60,19 +63,65 @@ function normalizeComponent(comp, sourceKind = 'component', index = 0) {
     brlen: comp?.brlen ?? comp?.branchLength ?? '',
     weight: comp?.weight ?? comp?.directWeight ?? '',
     ca,
+    ca97: comp?.ca97 ?? refNo,
+    ca98: comp?.ca98 ?? seqNo,
     source: { originalRefNo: cleanText(comp?.refNo || ''), ca97: cleanText(comp?.ca97 || ''), fromRefNo: cleanText(comp?.fromRefNo || ''), toRefNo: cleanText(comp?.toRefNo || '') }
   };
 }
 function countByType(blocks) { const out = {}; for (const b of blocks) out[b.type] = (out[b.type] || 0) + 1; return out; }
+function collectModuleDiagnostics(rows, key) { return (rows || []).flatMap(r => Array.isArray(r?.[key]) ? r[key] : []); }
+function preprocessRows(rows, cfg, label) {
+  const geometry = syncGeometryRows(rows);
+  const cpbp = applyCpBpFallbacks(geometry.rows, { cfg });
+  const brlen = resolveBrlenRows(cpbp.rows, { cfg });
+  const calculated = applyCalculatedColumns(brlen.rows, { cfg });
+  const supports = applySupportMappings(calculated.rows, cfg);
+  const out = supports.rows.map((r, i) => ({
+    ...r,
+    id: r.id || `${label}:${r.refNo || r.rawType || r.type || 'UNKNOWN'}:${i + 1}`,
+    phase4g: {
+      geometry: r.geometrySync || null,
+      brlen: r.brlenResolution || null,
+      support: r.supportMapping || null,
+      calculated: r.calculatedColumns || null,
+    }
+  }));
+  return {
+    rows: out,
+    summary: {
+      label,
+      geometry: geometry.summary,
+      cpbp: cpbp.summary,
+      brlen: brlen.summary,
+      calculated: calculated.summary,
+      supports: supports.summary,
+    },
+    diagnostics: [
+      ...collectModuleDiagnostics(cpbp.rows, 'cpBpFallbackDiagnostics'),
+      ...collectModuleDiagnostics(brlen.rows, 'brlenResolution').flatMap(x => x?.diagnostics || []),
+      ...collectModuleDiagnostics(supports.rows, 'supportMapping').flatMap(x => x?.diagnostics || []),
+    ]
+  };
+}
 function makeModel({ components = [], injectedPipes = [], pipelineRef = '', cfg = {} }) {
-  const componentBlocks = (Array.isArray(components) ? components : []).map((c, i) => normalizeComponent(c, 'component', i));
-  const bridgeBlocks = (Array.isArray(injectedPipes) ? injectedPipes : []).map((c, i) => normalizeComponent({ ...c, type: 'PIPE' }, 'bridge', i));
+  const rawComponentBlocks = (Array.isArray(components) ? components : []).map((c, i) => normalizeComponent(c, 'component', i));
+  const rawBridgeBlocks = (Array.isArray(injectedPipes) ? injectedPipes : []).map((c, i) => normalizeComponent({ ...c, type: 'PIPE' }, 'bridge', i));
+  const componentPrep = preprocessRows(rawComponentBlocks, cfg, 'component');
+  const bridgePrep = preprocessRows(rawBridgeBlocks, cfg, 'bridge');
+  const componentBlocks = componentPrep.rows;
+  const bridgeBlocks = bridgePrep.rows;
   const blocks = [...componentBlocks, ...bridgeBlocks];
-  return { engine: 'common', version: COMMON_BUILDER_VERSION, pipelineRef: cleanText(pipelineRef), cfgSnapshot: { decimalPrecision: cfg?.decimalPrecision, windowsLineEndings: cfg?.windowsLineEndings, maxEpCoordValue: cfg?.maxEpCoordValue, supportDefaultCoor: cfg?.supportDefaultCoor }, blocks, componentBlocks, bridgeBlocks, summary: { inputComponents: componentBlocks.length, injectedPipes: bridgeBlocks.length, emitEligible: blocks.filter(b => b.emitEligible).length, skipped: blocks.filter(b => b.skipReason).length, byType: countByType(blocks) } };
+  const phase4g = { component: componentPrep.summary, bridge: bridgePrep.summary, diagnostics: [...componentPrep.diagnostics, ...bridgePrep.diagnostics] };
+  return { engine: 'common', version: COMMON_BUILDER_VERSION, pipelineRef: cleanText(pipelineRef), cfgSnapshot: { decimalPrecision: cfg?.decimalPrecision, windowsLineEndings: cfg?.windowsLineEndings, maxEpCoordValue: cfg?.maxEpCoordValue, supportDefaultCoor: cfg?.supportDefaultCoor }, blocks, componentBlocks, bridgeBlocks, phase4g, summary: { inputComponents: componentBlocks.length, injectedPipes: bridgeBlocks.length, emitEligible: blocks.filter(b => b.emitEligible).length, skipped: blocks.filter(b => b.skipReason).length, byType: countByType(blocks) } };
 }
 function preflightModel(model) {
   const errors = [], warnings = [], infos = [];
   if (!model.pipelineRef) warnings.push({ id: 'CB-001', severity: 'WARNING', type: 'HEADER', message: 'PIPELINE-REFERENCE is blank', detail: 'Common builder received an empty pipelineRef', fixHint: 'Run Pipeline Ref lookup or ensure Stage 1 derives PIPELINE-REFERENCE' });
+  for (const d of model.phase4g?.diagnostics || []) {
+    const sev = String(d.severity || '').toLowerCase();
+    const item = { id: d.code || 'CB-4G', severity: sev === 'error' ? 'ERROR' : sev === 'warning' ? 'WARNING' : 'INFO', type: d.type || 'PHASE4G', message: d.message || 'Phase 4G preprocessing diagnostic', detail: JSON.stringify(d), fixHint: '' };
+    if (item.severity === 'ERROR') errors.push(item); else if (item.severity === 'WARNING') warnings.push(item); else infos.push(item);
+  }
   for (const block of model.blocks) {
     if (block.skipReason) { infos.push({ id: 'CB-010', severity: 'INFO', type: block.type, message: `${block.rawType} skipped from PCF emission`, detail: block.skipReason, fixHint: '' }); continue; }
     if (!block.emitEligible) warnings.push({ id: 'CB-011', severity: 'WARNING', type: block.rawType || block.type, message: `Unknown component type: ${block.rawType || block.type}`, detail: `RefNo: ${block.refNo || '?'}`, fixHint: 'Add the type to Common Builder mapping or upstream typeMap' });
@@ -85,22 +134,14 @@ function preflightModel(model) {
 }
 function checkerComponents(model) { return model.blocks.filter(b => !b.skipReason && b.emitEligible).map(b => ({ ...b, type: blockTypeForDiagnostics(b), ca: b.ca, refNo: b.refNo, seqNo: b.seqNo })); }
 function mergeDiagnostics(preflight, syntax) { return { errors: [...(preflight.errors || []), ...(syntax.errors || [])], warnings: [...(preflight.warnings || []), ...(syntax.warnings || [])], infos: [...(preflight.infos || []), ...(syntax.infos || [])] }; }
-function gateOptionsFromConfig(cfg = {}) {
-  return {
-    maxCritical: cfg.commonBuilderGateMaxCritical ?? 0,
-    maxMajor: cfg.commonBuilderGateMaxMajor ?? 0,
-    maxMinor: cfg.commonBuilderGateMaxMinor ?? Infinity,
-    requireLegacyCommonDiff: cfg.commonBuilderRunLegacyDiff !== false,
-    requireCommonBlocks: true,
-  };
-}
+function gateOptionsFromConfig(cfg = {}) { return { maxCritical: cfg.commonBuilderGateMaxCritical ?? 0, maxMajor: cfg.commonBuilderGateMaxMajor ?? 0, maxMinor: cfg.commonBuilderGateMaxMinor ?? Infinity, requireLegacyCommonDiff: cfg.commonBuilderRunLegacyDiff !== false, requireCommonBlocks: true }; }
 export function buildCommonPcf({ components = [], injectedPipes = [], pipelineRef = '', cfg = {}, logFn = () => {}, legacyEmitter = null } = {}) {
   const startedAt = Date.now();
   const model = makeModel({ components, injectedPipes, pipelineRef, cfg });
   const preflight = preflightModel(model);
   const syntax = runSyntaxCheck(checkerComponents(model), cfg);
   const diagnostics = mergeDiagnostics(preflight, syntax);
-  logFn('S4', 'common-builder-model-built', '', { version: COMMON_BUILDER_VERSION, blocks: model.blocks.length, components: model.summary.inputComponents, bridges: model.summary.injectedPipes, errors: diagnostics.errors.length, warnings: diagnostics.warnings.length, infos: diagnostics.infos.length });
+  logFn('S4', 'common-builder-model-built', '', { version: COMMON_BUILDER_VERSION, blocks: model.blocks.length, components: model.summary.inputComponents, bridges: model.summary.injectedPipes, errors: diagnostics.errors.length, warnings: diagnostics.warnings.length, infos: diagnostics.infos.length, phase4g: model.phase4g?.component });
   const emitResult = emitPcfModel(model, cfg);
   const pcfText = emitResult.pcfText || '';
   let legacyText = '';
@@ -115,7 +156,7 @@ export function buildCommonPcf({ components = [], injectedPipes = [], pipelineRe
     }
   }
   const gate = evaluatePcfDiffGate(diff, gateOptionsFromConfig(cfg));
-  const meta = { engine: 'common', phase: 'phase3-common-model-emitter-gated', builderVersion: COMMON_BUILDER_VERSION, emittedBy: 'pcf-model-emitter', startedAt, finishedAt: Date.now(), lineCount: pcfText ? pcfText.split(/\r?\n/).length : 0, blockCount: emitResult.meta.blockCount, diagnostics: { errors: diagnostics.errors.length, warnings: diagnostics.warnings.length, infos: diagnostics.infos.length }, diffSummary: diff?.summary || null, diffPass: diff?.pass ?? null, gate, gatePass: gate.pass, gateStatus: gate.status, summary: model.summary };
+  const meta = { engine: 'common', phase: 'phase4g-smart-preprocessed-common-emitter', builderVersion: COMMON_BUILDER_VERSION, emittedBy: 'pcf-model-emitter', startedAt, finishedAt: Date.now(), lineCount: pcfText ? pcfText.split(/\r?\n/).length : 0, blockCount: emitResult.meta.blockCount, diagnostics: { errors: diagnostics.errors.length, warnings: diagnostics.warnings.length, infos: diagnostics.infos.length }, phase4g: model.phase4g, diffSummary: diff?.summary || null, diffPass: diff?.pass ?? null, gate, gatePass: gate.pass, gateStatus: gate.status, summary: model.summary };
   try { window.__COMMON_PCF_BUILDER_LAST_RUN__ = { meta, model, diagnostics, legacyText, commonText: pcfText, diff, gate, emitResult }; } catch (_) {}
   logFn('S4', 'common-builder-emitted', '', meta);
   logFn('S4', 'common-builder-gate', '', { status: gate.status, summary: gate.summary, reasons: gate.reasons });

--- a/js/pcf-engine/common-pcf-builder.js
+++ b/js/pcf-engine/common-pcf-builder.js
@@ -1,0 +1,329 @@
+/**
+ * common-pcf-builder.js — Phase 1 Common PCF Builder
+ *
+ * Purpose:
+ *   Create a real, callable Common PCF Builder path without deleting or rewriting
+ *   the legacy Stage 4 emitter. Phase 1 deliberately delegates final text emission
+ *   to the existing legacy emitter after building a canonical model and running
+ *   common-engine diagnostics. This proves the common path is active and gives the
+ *   project a stable boundary for Phase 2/3 replacement of individual block emitters.
+ *
+ * Contract:
+ *   buildCommonPcf({ components, injectedPipes, pipelineRef, cfg, logFn, legacyEmitter })
+ *     -> { pcfText, model, diagnostics, meta }
+ */
+
+import { runSyntaxCheck } from './syntax-checker.js';
+
+const COMMON_BUILDER_VERSION = 'phase1.0.0';
+
+const EMIT_TYPES = new Set([
+  'PIPE',
+  'FLANGE',
+  'FBLI',
+  'BEND',
+  'TEE',
+  'OLET',
+  'VALVE',
+  'REDU',
+  'REDUCER-CONCENTRIC',
+  'REDUCER-ECCENTRIC',
+  'SUPPORT'
+]);
+
+const SKIP_TYPES = new Set(['GASK', 'PCOM', 'MISC', 'WELD', 'ATTA', 'INST']);
+
+function n(v, fallback = 0) {
+  const x = Number(v);
+  return Number.isFinite(x) ? x : fallback;
+}
+
+function cleanText(v) {
+  return String(v ?? '').replace(/=/g, '').trim();
+}
+
+function clonePoint(pt) {
+  if (!pt || typeof pt !== 'object') return null;
+  const x = n(pt.x, NaN);
+  const y = n(pt.y, NaN);
+  const z = n(pt.z, NaN);
+  if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) return null;
+  return { x, y, z };
+}
+
+function buildCa(comp) {
+  const ca = {};
+  for (let i = 1; i <= 10; i++) {
+    const direct = comp?.[`ca${i}`];
+    const nested = comp?.ca?.[String(i)] ?? comp?.ca?.[i];
+    const val = direct ?? nested;
+    if (val != null && val !== '') ca[String(i)] = String(val).trim();
+  }
+  if (comp?.weight != null && comp.weight !== '' && (ca['8'] == null || ca['8'] === '')) {
+    ca['8'] = String(comp.weight).trim();
+  }
+  return ca;
+}
+
+function normalizeType(type) {
+  const t = String(type || '').trim().toUpperCase();
+  if (t === 'REDU') return 'REDUCER-CONCENTRIC';
+  if (t === 'FBLI') return 'FLANGE';
+  return t;
+}
+
+function blockTypeForDiagnostics(comp) {
+  return normalizeType(comp?.type);
+}
+
+function normalizeComponent(comp, sourceKind = 'component', index = 0) {
+  const rawType = String(comp?.type || '').trim().toUpperCase();
+  const type = normalizeType(rawType);
+  const ca = buildCa(comp || {});
+  const refNo = cleanText(comp?.ca97 || comp?.refNo || comp?.fromRefNo || '');
+  const seqNo = comp?.seqNo ?? index + 1;
+
+  return {
+    id: `${sourceKind}:${refNo || rawType || 'UNKNOWN'}:${index + 1}`,
+    sourceKind,
+    rawType,
+    type,
+    emitEligible: EMIT_TYPES.has(rawType) || EMIT_TYPES.has(type),
+    skipReason: SKIP_TYPES.has(rawType) ? 'non-fitting passthrough' : '',
+    refNo,
+    seqNo,
+    bore: n(comp?.bore, 0),
+    branchBore: comp?.branchBore == null || comp.branchBore === '' ? null : n(comp.branchBore, 0),
+    ep1: clonePoint(comp?.ep1),
+    ep2: clonePoint(comp?.ep2),
+    cp: clonePoint(comp?.cp),
+    bp: clonePoint(comp?.bp),
+    supportCoor: clonePoint(comp?.supportCoor || comp?.supportCoord || comp?.cp),
+    skey: cleanText(comp?.skey || ''),
+    supportName: cleanText(comp?.supportName || ''),
+    supportGuid: cleanText(comp?.supportGuid || ''),
+    angleDeg: comp?.angleDeg ?? (rawType === 'BEND' || type === 'BEND' ? 90 : null),
+    radius: comp?.radius ?? comp?.bendRadius ?? null,
+    ca,
+    source: {
+      originalRefNo: cleanText(comp?.refNo || ''),
+      ca97: cleanText(comp?.ca97 || ''),
+      fromRefNo: cleanText(comp?.fromRefNo || ''),
+      toRefNo: cleanText(comp?.toRefNo || ''),
+    }
+  };
+}
+
+function countByType(blocks) {
+  const out = {};
+  for (const b of blocks) out[b.type] = (out[b.type] || 0) + 1;
+  return out;
+}
+
+function makeModel({ components = [], injectedPipes = [], pipelineRef = '', cfg = {} }) {
+  const componentBlocks = (Array.isArray(components) ? components : [])
+    .map((c, i) => normalizeComponent(c, 'component', i));
+  const bridgeBlocks = (Array.isArray(injectedPipes) ? injectedPipes : [])
+    .map((c, i) => normalizeComponent({ ...c, type: 'PIPE' }, 'bridge', i));
+
+  return {
+    engine: 'common',
+    version: COMMON_BUILDER_VERSION,
+    pipelineRef: cleanText(pipelineRef),
+    cfgSnapshot: {
+      decimalPrecision: cfg?.decimalPrecision,
+      windowsLineEndings: cfg?.windowsLineEndings,
+      maxEpCoordValue: cfg?.maxEpCoordValue,
+      supportDefaultCoor: cfg?.supportDefaultCoor,
+    },
+    blocks: [...componentBlocks, ...bridgeBlocks],
+    componentBlocks,
+    bridgeBlocks,
+    summary: {
+      inputComponents: componentBlocks.length,
+      injectedPipes: bridgeBlocks.length,
+      emitEligible: [...componentBlocks, ...bridgeBlocks].filter(b => b.emitEligible).length,
+      skipped: [...componentBlocks, ...bridgeBlocks].filter(b => b.skipReason).length,
+      byType: countByType([...componentBlocks, ...bridgeBlocks]),
+    }
+  };
+}
+
+function preflightModel(model) {
+  const errors = [];
+  const warnings = [];
+  const infos = [];
+
+  if (!model.pipelineRef) {
+    warnings.push({
+      id: 'CB-001',
+      severity: 'WARNING',
+      type: 'HEADER',
+      message: 'PIPELINE-REFERENCE is blank',
+      detail: 'Common builder received an empty pipelineRef',
+      fixHint: 'Run Pipeline Ref lookup or ensure Stage 1 derives PIPELINE-REFERENCE'
+    });
+  }
+
+  for (const block of model.blocks) {
+    if (block.skipReason) {
+      infos.push({
+        id: 'CB-010',
+        severity: 'INFO',
+        type: block.type,
+        message: `${block.rawType} skipped from PCF emission`,
+        detail: block.skipReason,
+        fixHint: ''
+      });
+      continue;
+    }
+
+    if (!block.emitEligible) {
+      warnings.push({
+        id: 'CB-011',
+        severity: 'WARNING',
+        type: block.rawType || block.type,
+        message: `Unknown component type: ${block.rawType || block.type}`,
+        detail: `RefNo: ${block.refNo || '?'}`,
+        fixHint: 'Add the type to Common Builder mapping or upstream typeMap'
+      });
+    }
+
+    if (['PIPE', 'FLANGE', 'VALVE', 'REDUCER-CONCENTRIC', 'REDUCER-ECCENTRIC'].includes(block.type)) {
+      if (!block.ep1 || !block.ep2) {
+        errors.push({
+          id: 'CB-020',
+          severity: 'ERROR',
+          type: block.type,
+          message: `${block.type} missing END-POINT geometry`,
+          detail: `RefNo: ${block.refNo || '?'}`,
+          fixHint: 'Check EP1/EP2 in Stage 1/Stage 3 before emitting PCF'
+        });
+      }
+    }
+
+    if (block.type === 'BEND' && (!block.ep1 || !block.ep2 || !block.cp)) {
+      errors.push({
+        id: 'CB-021',
+        severity: 'ERROR',
+        type: 'BEND',
+        message: 'BEND missing EP1/EP2/CP geometry',
+        detail: `RefNo: ${block.refNo || '?'}`,
+        fixHint: 'BEND requires two END-POINTs and one CENTRE-POINT'
+      });
+    }
+
+    if (block.type === 'TEE' && (!block.ep1 || !block.ep2 || !block.cp || !block.bp)) {
+      errors.push({
+        id: 'CB-022',
+        severity: 'ERROR',
+        type: 'TEE',
+        message: 'TEE missing EP1/EP2/CP/BP geometry',
+        detail: `RefNo: ${block.refNo || '?'}`,
+        fixHint: 'TEE requires END-POINTs, CENTRE-POINT and BRANCH1-POINT'
+      });
+    }
+
+    if (block.type === 'OLET' && (!block.cp || !block.bp)) {
+      errors.push({
+        id: 'CB-023',
+        severity: 'ERROR',
+        type: 'OLET',
+        message: 'OLET missing CP/BP geometry',
+        detail: `RefNo: ${block.refNo || '?'}`,
+        fixHint: 'OLET requires CENTRE-POINT and BRANCH1-POINT'
+      });
+    }
+  }
+
+  return { errors, warnings, infos };
+}
+
+function checkerComponents(model) {
+  return model.blocks
+    .filter(b => !b.skipReason && b.emitEligible)
+    .map(b => ({
+      ...b,
+      type: blockTypeForDiagnostics(b),
+      ca: b.ca,
+      refNo: b.refNo,
+      seqNo: b.seqNo,
+    }));
+}
+
+function mergeDiagnostics(preflight, syntax) {
+  return {
+    errors: [...(preflight.errors || []), ...(syntax.errors || [])],
+    warnings: [...(preflight.warnings || []), ...(syntax.warnings || [])],
+    infos: [...(preflight.infos || []), ...(syntax.infos || [])],
+  };
+}
+
+export function buildCommonPcf({
+  components = [],
+  injectedPipes = [],
+  pipelineRef = '',
+  cfg = {},
+  logFn = () => {},
+  legacyEmitter = null,
+} = {}) {
+  const startedAt = Date.now();
+  const model = makeModel({ components, injectedPipes, pipelineRef, cfg });
+  const preflight = preflightModel(model);
+  const syntax = runSyntaxCheck(checkerComponents(model), cfg);
+  const diagnostics = mergeDiagnostics(preflight, syntax);
+
+  logFn('S4', 'common-builder-model-built', '', {
+    version: COMMON_BUILDER_VERSION,
+    blocks: model.blocks.length,
+    components: model.summary.inputComponents,
+    bridges: model.summary.injectedPipes,
+    errors: diagnostics.errors.length,
+    warnings: diagnostics.warnings.length,
+    infos: diagnostics.infos.length,
+  });
+
+  if (typeof legacyEmitter !== 'function') {
+    throw new Error('Common PCF Builder Phase 1 requires a legacyEmitter callback for text emission.');
+  }
+
+  // Phase 1: legacy text emission is intentionally delegated after Common model
+  // normalization/diagnostics. Phase 2 replaces this with emitPcfModel(model, cfg).
+  const legacyResult = legacyEmitter(components, injectedPipes, pipelineRef, logFn);
+  const pcfText = legacyResult?.pcfText || '';
+
+  const meta = {
+    engine: 'common',
+    phase: 'phase1-delegates-to-legacy-emitter',
+    builderVersion: COMMON_BUILDER_VERSION,
+    emittedBy: 'legacy-emitter-delegate',
+    startedAt,
+    finishedAt: Date.now(),
+    lineCount: pcfText ? pcfText.split(/\r?\n/).length : 0,
+    diagnostics: {
+      errors: diagnostics.errors.length,
+      warnings: diagnostics.warnings.length,
+      infos: diagnostics.infos.length,
+    },
+    summary: model.summary,
+  };
+
+  try {
+    window.__COMMON_PCF_BUILDER_LAST_RUN__ = { meta, model, diagnostics };
+  } catch (_) {
+    // non-browser execution
+  }
+
+  logFn('S4', 'common-builder-emitted', '', meta);
+
+  return {
+    pcfText,
+    model,
+    diagnostics,
+    meta,
+  };
+}
+
+export function normalizeToPcfModel(args = {}) {
+  return makeModel(args);
+}

--- a/js/pcf-engine/cp-bp-fallbacks.js
+++ b/js/pcf-engine/cp-bp-fallbacks.js
@@ -1,0 +1,229 @@
+/**
+ * cp-bp-fallbacks.js — Phase 4C CP/BP fallback calculation
+ *
+ * Rules:
+ * - TEE CP = midpoint(EP1, EP2)
+ * - TEE/OLET BP = CP + BRLEN * branch direction unit vector
+ * - OLET CP uses existing CP if present; parent-axis inference is deferred until
+ *   parent pipe topology is passed into this module.
+ * - BEND CP is corner intersection for 90° axis-aligned bends, not midpoint.
+ */
+
+import { resolveBrlen } from './brlen-resolver.js';
+
+function n(value, fallback = null) {
+  if (value == null || value === '') return fallback;
+  const x = Number(value);
+  return Number.isFinite(x) ? x : fallback;
+}
+
+function clean(value) {
+  return String(value ?? '').trim();
+}
+
+function point(value) {
+  if (!value || typeof value !== 'object') return null;
+  const x = n(value.x), y = n(value.y), z = n(value.z);
+  return [x, y, z].every(v => v != null) ? { x, y, z } : null;
+}
+
+function midpoint(a, b) {
+  const p1 = point(a), p2 = point(b);
+  if (!p1 || !p2) return null;
+  return {
+    x: (p1.x + p2.x) / 2,
+    y: (p1.y + p2.y) / 2,
+    z: (p1.z + p2.z) / 2,
+  };
+}
+
+function mag(v) {
+  return Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+}
+
+function sub(a, b) {
+  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z };
+}
+
+function add(a, b) {
+  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
+}
+
+function scale(v, s) {
+  return { x: v.x * s, y: v.y * s, z: v.z * s };
+}
+
+function unit(v) {
+  const m = mag(v);
+  if (m < 1e-9) return null;
+  return scale(v, 1 / m);
+}
+
+function typeOf(component) {
+  return clean(component?.type || component?.rawType).toUpperCase();
+}
+
+function directionFromAxis(axis) {
+  const a = clean(axis).toLowerCase();
+  if (['east', '+x', 'x+', 'e'].includes(a)) return { x: 1, y: 0, z: 0 };
+  if (['west', '-x', 'x-', 'w'].includes(a)) return { x: -1, y: 0, z: 0 };
+  if (['north', '+y', 'y+', 'n'].includes(a)) return { x: 0, y: 1, z: 0 };
+  if (['south', '-y', 'y-', 's'].includes(a)) return { x: 0, y: -1, z: 0 };
+  if (['up', '+z', 'z+', 'u'].includes(a)) return { x: 0, y: 0, z: 1 };
+  if (['down', '-z', 'z-', 'd'].includes(a)) return { x: 0, y: 0, z: -1 };
+  return null;
+}
+
+function inferBranchDirection(component, cp) {
+  const explicit = directionFromAxis(component?.branchAxis || component?.branchDirection || component?.axis || component?.direction);
+  if (explicit) return { dir: explicit, source: 'explicit-axis' };
+
+  const existingBp = point(component?.bp);
+  if (existingBp && cp) {
+    const u = unit(sub(existingBp, cp));
+    if (u) return { dir: u, source: 'existing-bp' };
+  }
+
+  return { dir: null, source: 'unresolved' };
+}
+
+function cornerCpForBend(component) {
+  const ep1 = point(component?.ep1);
+  const ep2 = point(component?.ep2);
+  if (!ep1 || !ep2) return null;
+
+  const candidates = [
+    { x: ep1.x, y: ep1.y, z: ep2.z },
+    { x: ep1.x, y: ep2.y, z: ep1.z },
+    { x: ep2.x, y: ep1.y, z: ep1.z },
+    { x: ep1.x, y: ep2.y, z: ep2.z },
+    { x: ep2.x, y: ep1.y, z: ep2.z },
+    { x: ep2.x, y: ep2.y, z: ep1.z },
+  ];
+
+  const radius = n(component?.radius ?? component?.bendRadius);
+  if (radius != null && radius > 0) {
+    let best = null;
+    let bestErr = Infinity;
+    for (const c of candidates) {
+      const d1 = mag(sub(c, ep1));
+      const d2 = mag(sub(c, ep2));
+      const err = Math.abs(d1 - radius) + Math.abs(d2 - radius);
+      if (err < bestErr) { bestErr = err; best = c; }
+    }
+    return best;
+  }
+
+  // If no radius is available, choose the right-angle corner candidate with
+  // equal distances if possible. This is a best-effort fallback and should be
+  // accompanied by a diagnostic.
+  let best = null;
+  let bestErr = Infinity;
+  for (const c of candidates) {
+    const d1 = mag(sub(c, ep1));
+    const d2 = mag(sub(c, ep2));
+    const err = Math.abs(d1 - d2);
+    if (d1 > 1e-6 && d2 > 1e-6 && err < bestErr) { bestErr = err; best = c; }
+  }
+  return best;
+}
+
+export function applyCpBpFallback(component, options = {}) {
+  const t = typeOf(component);
+  const diagnostics = [];
+  let out = { ...component };
+
+  if (t === 'TEE') {
+    if (!point(out.cp)) {
+      const cp = midpoint(out.ep1, out.ep2);
+      if (cp) {
+        out.cp = cp;
+        diagnostics.push({ severity: 'info', code: 'CP-TEE-MIDPOINT', message: 'TEE CP calculated as midpoint of EP1/EP2.' });
+      } else {
+        diagnostics.push({ severity: 'error', code: 'CP-TEE-MISSING', message: 'TEE CP unresolved: EP1/EP2 not available.' });
+      }
+    }
+
+    if (!point(out.bp)) {
+      const cp = point(out.cp);
+      const br = resolveBrlen(out, options);
+      const dir = inferBranchDirection(out, cp);
+      if (cp && br.brlen != null && dir.dir) {
+        out.bp = add(cp, scale(dir.dir, br.brlen));
+        out.brlen = br.brlen;
+        diagnostics.push({ severity: 'info', code: 'BP-TEE-BRLEN', message: 'TEE BP calculated from CP + BRLEN * direction.', source: br.source, directionSource: dir.source });
+      } else {
+        diagnostics.push({ severity: 'error', code: 'BP-TEE-INCOMPLETE', message: 'TEE BP unresolved: CP, BRLEN, or branch direction missing.', brlen: br, directionSource: dir.source });
+      }
+    }
+
+    if (out.branchBore == null && out.bore != null) {
+      out.branchBore = out.bore;
+      diagnostics.push({ severity: 'info', code: 'BORE-TEE-BRANCH-FALLBACK', message: 'TEE branch bore defaulted to header bore.' });
+    }
+  }
+
+  if (t === 'OLET') {
+    if (!point(out.cp)) {
+      diagnostics.push({ severity: 'warning', code: 'CP-OLET-PARENT-AXIS-DEFERRED', message: 'OLET CP from parent pipe axis requires topology context and is deferred.' });
+    }
+
+    if (out.branchBore == null) {
+      out.branchBore = 50;
+      diagnostics.push({ severity: 'info', code: 'BORE-OLET-BRANCH-FALLBACK', message: 'OLET branch bore defaulted to 50 mm.' });
+    }
+
+    if (!point(out.bp)) {
+      const cp = point(out.cp);
+      const br = resolveBrlen(out, options);
+      const dir = inferBranchDirection(out, cp);
+      if (cp && br.brlen != null && dir.dir) {
+        out.bp = add(cp, scale(dir.dir, br.brlen));
+        out.brlen = br.brlen;
+        diagnostics.push({ severity: 'info', code: 'BP-OLET-BRLEN', message: 'OLET BP calculated from CP + BRLEN * direction.', source: br.source, directionSource: dir.source });
+      } else {
+        diagnostics.push({ severity: 'error', code: 'BP-OLET-INCOMPLETE', message: 'OLET BP unresolved: CP, BRLEN, or branch direction missing.', brlen: br, directionSource: dir.source });
+      }
+    }
+  }
+
+  if (t === 'BEND') {
+    if (!point(out.cp)) {
+      const cp = cornerCpForBend(out);
+      if (cp) {
+        out.cp = cp;
+        diagnostics.push({ severity: out.radius || out.bendRadius ? 'info' : 'warning', code: 'CP-BEND-CORNER', message: 'BEND CP calculated as axis-aligned corner intersection, not midpoint.' });
+      } else {
+        diagnostics.push({ severity: 'error', code: 'CP-BEND-MISSING', message: 'BEND CP unresolved: EP1/EP2 not available.' });
+      }
+    }
+  }
+
+  if (point(out.cp) && out.cpBore == null && out.bore != null) {
+    out.cpBore = out.bore;
+  }
+
+  out.cpBpFallbackDiagnostics = diagnostics;
+  return out;
+}
+
+export function applyCpBpFallbacks(rows = [], options = {}) {
+  const out = (Array.isArray(rows) ? rows : []).map(row => applyCpBpFallback(row, options));
+  return {
+    rows: out,
+    summary: {
+      inputRows: Array.isArray(rows) ? rows.length : 0,
+      outputRows: out.length,
+      diagnostics: out.reduce((acc, r) => acc + (r.cpBpFallbackDiagnostics?.length || 0), 0),
+      errors: out.reduce((acc, r) => acc + (r.cpBpFallbackDiagnostics || []).filter(d => d.severity === 'error').length, 0),
+      warnings: out.reduce((acc, r) => acc + (r.cpBpFallbackDiagnostics || []).filter(d => d.severity === 'warning').length, 0),
+    }
+  };
+}
+
+try {
+  if (typeof window !== 'undefined') {
+    window.applyPcfCpBpFallback = applyCpBpFallback;
+    window.applyPcfCpBpFallbacks = applyCpBpFallbacks;
+  }
+} catch (_) {}

--- a/js/pcf-engine/geometry-sync.js
+++ b/js/pcf-engine/geometry-sync.js
@@ -1,0 +1,231 @@
+/**
+ * geometry-sync.js — Phase 4B Bi-directional coordinate calculator
+ *
+ * Supports three reconstruction paths:
+ *   Path A: EP1/EP2 available -> DELTA + LEN/AXIS
+ *   Path B: DELTA available   -> EP1/EP2 + LEN/AXIS
+ *   Path C: LEN/AXIS available -> DELTA + EP1/EP2
+ *
+ * Chaining rule:
+ *   If EP1 is missing and the row is reconstructed from DELTA or LEN/AXIS,
+ *   EP1 = previous row EP2. If no previous EP2 exists, EP1 = origin.
+ */
+
+const ORIGIN = Object.freeze({ x: 0, y: 0, z: 0 });
+
+function n(value, fallback = null) {
+  if (value == null || value === '') return fallback;
+  const x = Number(value);
+  return Number.isFinite(x) ? x : fallback;
+}
+
+function point(value) {
+  if (!value || typeof value !== 'object') return null;
+  const x = n(value.x), y = n(value.y), z = n(value.z);
+  return [x, y, z].every(v => v != null) ? { x, y, z } : null;
+}
+
+function clonePoint(pt) {
+  return pt ? { x: pt.x, y: pt.y, z: pt.z } : null;
+}
+
+function add(a, b) {
+  return { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z };
+}
+
+function sub(a, b) {
+  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z };
+}
+
+function hasAnyDelta(row) {
+  return [row?.deltaX, row?.deltaY, row?.deltaZ].some(v => n(v) != null);
+}
+
+function hasAnyLenAxis(row) {
+  return [row?.len1, row?.len2, row?.len3].some(v => n(v) != null) ||
+    [row?.axis1, row?.axis2, row?.axis3].some(v => String(v || '').trim());
+}
+
+function hasBothEps(row) {
+  return !!point(row?.ep1) && !!point(row?.ep2);
+}
+
+function axisLabel(delta, axis) {
+  if (delta == null || Math.abs(delta) < 1e-9) return '';
+  if (axis === 'x') return delta > 0 ? 'East' : 'West';
+  if (axis === 'y') return delta > 0 ? 'North' : 'South';
+  if (axis === 'z') return delta > 0 ? 'Up' : 'Down';
+  return '';
+}
+
+export function deltaToLenAxis(delta, axis) {
+  const d = n(delta, 0);
+  if (Math.abs(d) < 1e-9) return { len: null, axis: '' };
+  return { len: d, axis: axisLabel(d, axis) };
+}
+
+export function axisToSign(axis) {
+  const a = String(axis || '').trim().toLowerCase();
+  if (['east', '+x', 'x+', 'e'].includes(a)) return 1;
+  if (['west', '-x', 'x-', 'w'].includes(a)) return -1;
+  if (['north', '+y', 'y+', 'n'].includes(a)) return 1;
+  if (['south', '-y', 'y-', 's'].includes(a)) return -1;
+  if (['up', '+z', 'z+', 'u'].includes(a)) return 1;
+  if (['down', '-z', 'z-', 'd'].includes(a)) return -1;
+  return 0;
+}
+
+export function lenAxisToDelta(length, axis) {
+  const len = n(length, 0);
+  const sign = axisToSign(axis);
+  if (!sign || Math.abs(len) < 1e-9) return 0;
+  return Math.abs(len) * sign;
+}
+
+export function calculateDeltaFromEps(ep1, ep2) {
+  const a = point(ep1), b = point(ep2);
+  if (!a || !b) return null;
+  return sub(b, a);
+}
+
+export function calculateLenAxisFromDelta(delta) {
+  const dx = n(delta?.x, 0), dy = n(delta?.y, 0), dz = n(delta?.z, 0);
+  const x = deltaToLenAxis(dx, 'x');
+  const y = deltaToLenAxis(dy, 'y');
+  const z = deltaToLenAxis(dz, 'z');
+  return {
+    len1: x.len,
+    axis1: x.axis,
+    len2: y.len,
+    axis2: y.axis,
+    len3: z.len,
+    axis3: z.axis,
+  };
+}
+
+export function calculateDeltaFromLenAxis(row) {
+  return {
+    x: lenAxisToDelta(row?.len1, row?.axis1),
+    y: lenAxisToDelta(row?.len2, row?.axis2),
+    z: lenAxisToDelta(row?.len3, row?.axis3),
+  };
+}
+
+function deltaFromRow(row) {
+  return {
+    x: n(row?.deltaX, 0),
+    y: n(row?.deltaY, 0),
+    z: n(row?.deltaZ, 0),
+  };
+}
+
+function startPoint(row, prevEp2) {
+  return point(row?.ep1) || point(prevEp2) || clonePoint(ORIGIN);
+}
+
+function applyDelta(row, delta, prevEp2) {
+  const ep1 = startPoint(row, prevEp2);
+  const ep2 = point(row?.ep2) || add(ep1, delta);
+  const lenAxis = calculateLenAxisFromDelta(delta);
+  return {
+    ...row,
+    ep1,
+    ep2,
+    deltaX: delta.x,
+    deltaY: delta.y,
+    deltaZ: delta.z,
+    ...lenAxis,
+    geometrySync: {
+      path: row.geometrySync?.path || '',
+      source: row.geometrySync?.source || '',
+      chainedFromPrevious: !point(row?.ep1) && !!point(prevEp2),
+      usedOrigin: !point(row?.ep1) && !point(prevEp2),
+    }
+  };
+}
+
+export function syncGeometryRow(row, options = {}) {
+  const prevEp2 = options.prevEp2 || null;
+  const ep1 = point(row?.ep1);
+  const ep2 = point(row?.ep2);
+  const diagnostics = [];
+
+  if (hasBothEps(row)) {
+    const delta = calculateDeltaFromEps(ep1, ep2);
+    const synced = applyDelta({ ...row, geometrySync: { path: 'A', source: 'EP1/EP2' } }, delta, prevEp2);
+    synced.geometryDiagnostics = diagnostics;
+    return synced;
+  }
+
+  if (hasAnyDelta(row)) {
+    const delta = deltaFromRow(row);
+    const synced = applyDelta({ ...row, geometrySync: { path: 'B', source: 'DELTA' } }, delta, prevEp2);
+    synced.geometryDiagnostics = diagnostics;
+    return synced;
+  }
+
+  if (hasAnyLenAxis(row)) {
+    const delta = calculateDeltaFromLenAxis(row);
+    const synced = applyDelta({ ...row, geometrySync: { path: 'C', source: 'LEN/AXIS' } }, delta, prevEp2);
+    synced.geometryDiagnostics = diagnostics;
+    return synced;
+  }
+
+  diagnostics.push({
+    severity: 'warning',
+    code: 'GS-001',
+    message: 'No EP, DELTA, or LEN/AXIS data available for geometry sync.',
+  });
+
+  return {
+    ...row,
+    geometrySync: { path: 'none', source: 'none', chainedFromPrevious: false, usedOrigin: false },
+    geometryDiagnostics: diagnostics,
+  };
+}
+
+export function syncGeometryRows(rows = [], options = {}) {
+  const out = [];
+  let prevEp2 = point(options.startEp2) || null;
+  for (const row of rows || []) {
+    const synced = syncGeometryRow(row, { ...options, prevEp2 });
+    out.push(synced);
+    if (point(synced.ep2)) prevEp2 = point(synced.ep2);
+  }
+  return {
+    rows: out,
+    summary: {
+      inputRows: Array.isArray(rows) ? rows.length : 0,
+      outputRows: out.length,
+      pathA: out.filter(r => r.geometrySync?.path === 'A').length,
+      pathB: out.filter(r => r.geometrySync?.path === 'B').length,
+      pathC: out.filter(r => r.geometrySync?.path === 'C').length,
+      unresolved: out.filter(r => r.geometrySync?.path === 'none').length,
+      chainedRows: out.filter(r => r.geometrySync?.chainedFromPrevious).length,
+      originRows: out.filter(r => r.geometrySync?.usedOrigin).length,
+    }
+  };
+}
+
+export function validateGeometryRoundTrip(row, tolerance = 0.001) {
+  const synced = syncGeometryRow(row);
+  const errors = [];
+  if (point(synced.ep1) && point(synced.ep2)) {
+    const delta = calculateDeltaFromEps(synced.ep1, synced.ep2);
+    const dxOk = Math.abs(delta.x - n(synced.deltaX, 0)) <= tolerance;
+    const dyOk = Math.abs(delta.y - n(synced.deltaY, 0)) <= tolerance;
+    const dzOk = Math.abs(delta.z - n(synced.deltaZ, 0)) <= tolerance;
+    if (!dxOk) errors.push({ field: 'deltaX', expected: delta.x, actual: synced.deltaX });
+    if (!dyOk) errors.push({ field: 'deltaY', expected: delta.y, actual: synced.deltaY });
+    if (!dzOk) errors.push({ field: 'deltaZ', expected: delta.z, actual: synced.deltaZ });
+  }
+  return { pass: errors.length === 0, errors, synced };
+}
+
+try {
+  if (typeof window !== 'undefined') {
+    window.syncPcfGeometryRow = syncGeometryRow;
+    window.syncPcfGeometryRows = syncGeometryRows;
+    window.validatePcfGeometryRoundTrip = validateGeometryRoundTrip;
+  }
+} catch (_) {}

--- a/js/pcf-engine/pcf-diff-gate.js
+++ b/js/pcf-engine/pcf-diff-gate.js
@@ -1,0 +1,122 @@
+/**
+ * pcf-diff-gate.js — Phase 3E Legacy/Common certification gate
+ *
+ * Converts a diffPcfOutputs(...) result into a deterministic pass/fail gate.
+ * Intended for:
+ * - Browser console checks
+ * - Future Playwright tests
+ * - Future benchmark runner / CI
+ */
+
+const DEFAULT_GATE = Object.freeze({
+  maxCritical: 0,
+  maxMajor: 0,
+  maxMinor: Infinity,
+  requireLegacyCommonDiff: true,
+  requireCommonBlocks: true,
+});
+
+function n(value, fallback = 0) {
+  const x = Number(value);
+  return Number.isFinite(x) ? x : fallback;
+}
+
+function mergeOptions(options = {}) {
+  return { ...DEFAULT_GATE, ...(options || {}) };
+}
+
+function emptySummary() {
+  return {
+    legacyBlockCount: 0,
+    commonBlockCount: 0,
+    total: 0,
+    critical: 0,
+    major: 0,
+    minor: 0,
+  };
+}
+
+export function evaluatePcfDiffGate(diff, options = {}) {
+  const gate = mergeOptions(options);
+  const summary = diff?.summary || emptySummary();
+  const reasons = [];
+
+  if (gate.requireLegacyCommonDiff && !diff) {
+    reasons.push('Legacy/Common diff result is missing.');
+  }
+
+  if (gate.requireCommonBlocks && n(summary.commonBlockCount) <= 0) {
+    reasons.push('Common output has zero parsed PCF blocks.');
+  }
+
+  if (n(summary.critical) > gate.maxCritical) {
+    reasons.push(`Critical diffs ${summary.critical} exceed allowed ${gate.maxCritical}.`);
+  }
+
+  if (n(summary.major) > gate.maxMajor) {
+    reasons.push(`Major diffs ${summary.major} exceed allowed ${gate.maxMajor}.`);
+  }
+
+  if (Number.isFinite(gate.maxMinor) && n(summary.minor) > gate.maxMinor) {
+    reasons.push(`Minor diffs ${summary.minor} exceed allowed ${gate.maxMinor}.`);
+  }
+
+  const pass = reasons.length === 0;
+
+  return {
+    pass,
+    status: pass ? 'PASS' : 'FAIL',
+    reasons,
+    thresholds: gate,
+    summary: {
+      legacyBlockCount: n(summary.legacyBlockCount),
+      commonBlockCount: n(summary.commonBlockCount),
+      total: n(summary.total),
+      critical: n(summary.critical),
+      major: n(summary.major),
+      minor: n(summary.minor),
+    },
+  };
+}
+
+export function summarizeDiffsForReport(diff, limit = 50) {
+  const rows = Array.isArray(diff?.diffs) ? diff.diffs : [];
+  return rows.slice(0, limit).map((d, i) => ({
+    '#': i + 1,
+    severity: d.severity || '',
+    path: d.path || '',
+    legacy: d.legacy == null ? '' : String(d.legacy),
+    common: d.common == null ? '' : String(d.common),
+    message: d.message || '',
+  }));
+}
+
+export function evaluateLastCommonRun(options = {}) {
+  const run = typeof window !== 'undefined' ? window.__COMMON_PCF_BUILDER_LAST_RUN__ : null;
+  const gate = evaluatePcfDiffGate(run?.diff || null, options);
+  return {
+    ...gate,
+    meta: run?.meta || null,
+    emitMeta: run?.emitResult?.meta || null,
+    diffPreview: summarizeDiffsForReport(run?.diff || null, options.previewLimit ?? 50),
+  };
+}
+
+export function printLastCommonGate(options = {}) {
+  const result = evaluateLastCommonRun(options);
+  if (typeof console !== 'undefined') {
+    console.log(`[Common PCF Gate] ${result.status}`, result.summary, result.reasons);
+    if (result.diffPreview?.length) console.table(result.diffPreview);
+  }
+  return result;
+}
+
+try {
+  if (typeof window !== 'undefined') {
+    window.evaluatePcfDiffGate = evaluatePcfDiffGate;
+    window.evaluateLastCommonRun = evaluateLastCommonRun;
+    window.printLastCommonGate = printLastCommonGate;
+  }
+} catch (_) {
+  // non-browser execution
+}

--- a/js/pcf-engine/pcf-model-emitter.js
+++ b/js/pcf-engine/pcf-model-emitter.js
@@ -1,7 +1,9 @@
 /**
- * pcf-model-emitter.js — Common PCF Builder Phase 2
+ * pcf-model-emitter.js — Common PCF Builder Phase 2/3
  *
  * Converts canonical Common PCF model blocks into PCF text.
+ * Phase 3B adds bridge ordering parity: bridge PIPE blocks are emitted
+ * immediately after their originating component, matching legacy Stage 4.
  */
 
 import { emitCABlock } from './pcf-block-schema.js';
@@ -13,48 +15,29 @@ function n(value, fallback = 0) {
   const x = Number(value);
   return Number.isFinite(x) ? x : fallback;
 }
-
-function cleanText(value) {
-  return String(value ?? '').replace(/=/g, '').trim();
-}
-
-function p(cfg) {
-  return Number.isInteger(cfg?.decimalPrecision) ? cfg.decimalPrecision : 4;
-}
-
-function fmtNum(value, cfg) {
-  return n(value, 0).toFixed(p(cfg));
-}
-
+function cleanText(value) { return String(value ?? '').replace(/=/g, '').trim(); }
+function p(cfg) { return Number.isInteger(cfg?.decimalPrecision) ? cfg.decimalPrecision : 4; }
+function fmtNum(value, cfg) { return n(value, 0).toFixed(p(cfg)); }
 function fmtCoord(pt, bore, cfg) {
   return `${fmtNum(pt?.x, cfg)} ${fmtNum(pt?.y, cfg)} ${fmtNum(pt?.z, cfg)} ${fmtNum(bore, cfg)}`;
 }
-
 function emitMsgSq(parts, cfg) {
   if (cfg?.messageSquareEnabled === false) return [];
   return ['MESSAGE-SQUARE', `${INDENT}${parts.filter(Boolean).join(', ')}`];
 }
-
 function emitSkey(block, fallback = '') {
   const skey = cleanText(block?.skey || fallback);
   return skey ? [`${INDENT}<SKEY> ${skey}`] : [];
 }
-
 function caFor(block) {
   const ca = { ...(block?.ca || {}) };
   if (block?.weight != null && block.weight !== '' && !ca['8']) ca['8'] = String(block.weight);
   return ca;
 }
-
-function refFor(block, fallback = '') {
-  return cleanText(block?.refNo || block?.source?.originalRefNo || fallback);
-}
-
+function refFor(block, fallback = '') { return cleanText(block?.refNo || block?.source?.originalRefNo || fallback); }
 function lengthAxis(ep1, ep2, cfg) {
   if (!ep1 || !ep2) return {};
-  const dx = n(ep2.x) - n(ep1.x);
-  const dy = n(ep2.y) - n(ep1.y);
-  const dz = n(ep2.z) - n(ep1.z);
+  const dx = n(ep2.x) - n(ep1.x), dy = n(ep2.y) - n(ep1.y), dz = n(ep2.z) - n(ep1.z);
   const axis = (delta, pos, neg) => Math.abs(delta) < 1e-6 ? '' : (delta > 0 ? pos : neg);
   return {
     len1: Math.abs(dx) > 1e-6 ? fmtNum(dx, cfg) : '', axis1: axis(dx, 'EAST', 'WEST'),
@@ -62,16 +45,10 @@ function lengthAxis(ep1, ep2, cfg) {
     len3: Math.abs(dz) > 1e-6 ? fmtNum(dz, cfg) : '', axis3: axis(dz, 'UP', 'DOWN'),
   };
 }
-
 function primaryLengthText(block, cfg) {
   const la = lengthAxis(block.ep1, block.ep2, cfg);
-  return [
-    la.len1 ? `${la.len1}MM ${la.axis1}` : '',
-    la.len2 ? `${la.len2}MM ${la.axis2}` : '',
-    la.len3 ? `${la.len3}MM ${la.axis3}` : '',
-  ].filter(Boolean).join(' + ');
+  return [la.len1 ? `${la.len1}MM ${la.axis1}` : '', la.len2 ? `${la.len2}MM ${la.axis2}` : '', la.len3 ? `${la.len3}MM ${la.axis3}` : ''].filter(Boolean).join(' + ');
 }
-
 function firstLengthText(block, cfg) {
   const la = lengthAxis(block.ep1, block.ep2, cfg);
   if (la.len1) return `${la.len1}MM ${la.axis1}`;
@@ -79,137 +56,70 @@ function firstLengthText(block, cfg) {
   if (la.len3) return `${la.len3}MM ${la.axis3}`;
   return '';
 }
-
 function buildHeader(model) {
   const pipelineRef = cleanText(model?.pipelineRef || '');
-  return [
-    'ISOGEN-FILES ISOGEN.FLS',
-    'UNITS-BORE MM',
-    'UNITS-CO-ORDS MM',
-    'UNITS-WEIGHT KGS',
-    'UNITS-BOLT-DIA MM',
-    'UNITS-BOLT-LENGTH MM',
-    `PIPELINE-REFERENCE ${pipelineRef}`,
-    `${INDENT}PROJECT-IDENTIFIER P1`,
-    `${INDENT}AREA A1`,
-    ''
-  ];
+  return ['ISOGEN-FILES ISOGEN.FLS','UNITS-BORE MM','UNITS-CO-ORDS MM','UNITS-WEIGHT KGS','UNITS-BOLT-DIA MM','UNITS-BOLT-LENGTH MM',`PIPELINE-REFERENCE ${pipelineRef}`,`${INDENT}PROJECT-IDENTIFIER P1`,`${INDENT}AREA A1`,''];
 }
-
-function emitCA(block, blockType, seq) {
-  return emitCABlock(caFor(block), blockType, refFor(block), seq);
-}
-
+function emitCA(block, blockType, seq) { return emitCABlock(caFor(block), blockType, refFor(block), String(seq)); }
 function emitPipe(block, seq, model, cfg) {
   if (!block.ep1 || !block.ep2) return [];
-  const refNo = refFor(block);
-  const lenText = primaryLengthText(block, cfg);
-  const lines = [];
+  const refNo = refFor(block), lenText = primaryLengthText(block, cfg), lines = [];
   lines.push(...emitMsgSq(['PIPE', refNo ? `RefNo:=${refNo}` : '', lenText ? `LENGTH=${lenText}` : '', `SeqNo:${seq}`], cfg));
-  lines.push('PIPE');
-  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`);
-  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`);
+  lines.push('PIPE', `${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`, `${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`);
   if (model?.pipelineRef) lines.push(`${INDENT}PIPELINE-REFERENCE ${cleanText(model.pipelineRef)}`);
-  lines.push(...emitSkey(block));
-  lines.push(...emitCA(block, 'PIPE', seq));
-  lines.push('');
+  lines.push(...emitSkey(block), ...emitCA(block, 'PIPE', seq), '');
   return lines;
 }
-
 function emitFlange(block, seq, cfg) {
   if (!block.ep1 || !block.ep2) return [];
-  const refNo = refFor(block);
-  const lenText = firstLengthText(block, cfg);
-  const lines = [];
+  const refNo = refFor(block), lenText = firstLengthText(block, cfg), lines = [];
   lines.push(...emitMsgSq(['FLANGE', lenText ? `LENGTH=${lenText}` : '', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`], cfg));
-  lines.push('FLANGE');
-  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`);
-  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`);
-  lines.push(...emitSkey(block, block.rawType === 'FBLI' ? 'BLFL' : ''));
-  lines.push(...emitCA(block, 'FLANGE', seq));
-  lines.push('');
+  lines.push('FLANGE', `${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`, `${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`);
+  lines.push(...emitSkey(block, block.rawType === 'FBLI' ? 'BLFL' : ''), ...emitCA(block, 'FLANGE', seq), '');
   return lines;
 }
-
 function emitBend(block, seq, cfg) {
   if (!block.ep1 || !block.ep2 || !block.cp) return [];
-  const refNo = refFor(block);
-  const lines = [];
+  const refNo = refFor(block), lines = [];
   lines.push(...emitMsgSq(['BEND', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`], cfg));
-  lines.push('BEND');
-  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`);
-  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`);
-  lines.push(`${INDENT}CENTRE-POINT  ${fmtCoord(block.cp, block.bore, cfg)}`);
-  lines.push(...emitSkey(block));
-  lines.push(`${INDENT}ANGLE ${fmtNum(block.angleDeg ?? 90, cfg)}`);
+  lines.push('BEND', `${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`, `${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`, `${INDENT}CENTRE-POINT  ${fmtCoord(block.cp, block.bore, cfg)}`);
+  lines.push(...emitSkey(block), `${INDENT}ANGLE ${fmtNum(block.angleDeg ?? 90, cfg)}`);
   if (block.radius || block.bendRadius) lines.push(`${INDENT}BEND-RADIUS ${fmtNum(block.radius || block.bendRadius, cfg)}`);
-  lines.push(...emitCA(block, 'BEND', seq));
-  lines.push('');
+  lines.push(...emitCA(block, 'BEND', seq), '');
   return lines;
 }
-
 function emitTee(block, seq, cfg) {
   if (!block.ep1 || !block.ep2 || !block.cp || !block.bp) return [];
-  const refNo = refFor(block);
-  const brlen = block.brlen ?? block.branchLength ?? '';
-  const lines = [];
+  const refNo = refFor(block), brlen = block.brlen ?? block.branchLength ?? '', lines = [];
   lines.push(...emitMsgSq(['TEE', brlen !== '' ? `LENGTH=${brlen}MM` : '', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`, brlen !== '' ? `BrLen=${brlen}MM` : ''], cfg));
-  lines.push('TEE');
-  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`);
-  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`);
-  lines.push(`${INDENT}CENTRE-POINT  ${fmtCoord(block.cp, block.bore, cfg)}`);
-  lines.push(`${INDENT}BRANCH1-POINT ${fmtCoord(block.bp, block.branchBore || block.bore, cfg)}`);
-  lines.push(...emitSkey(block));
-  lines.push(...emitCA(block, 'TEE', seq));
-  lines.push('');
+  lines.push('TEE', `${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`, `${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`, `${INDENT}CENTRE-POINT  ${fmtCoord(block.cp, block.bore, cfg)}`, `${INDENT}BRANCH1-POINT ${fmtCoord(block.bp, block.branchBore || block.bore, cfg)}`);
+  lines.push(...emitSkey(block), ...emitCA(block, 'TEE', seq), '');
   return lines;
 }
-
 function emitOlet(block, seq, cfg) {
   if (!block.cp || !block.bp) return [];
-  const refNo = refFor(block);
-  const brlen = block.brlen ?? block.branchLength ?? '';
-  const lines = [];
+  const refNo = refFor(block), brlen = block.brlen ?? block.branchLength ?? '', lines = [];
   lines.push(...emitMsgSq(['OLET', brlen !== '' ? `BrLen=${brlen}MM` : '', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`], cfg));
-  lines.push('OLET');
-  lines.push(`${INDENT}CENTRE-POINT  ${fmtCoord(block.cp, block.bore, cfg)}`);
-  lines.push(`${INDENT}BRANCH1-POINT ${fmtCoord(block.bp, block.branchBore || 50, cfg)}`);
-  lines.push(...emitSkey(block));
-  lines.push(...emitCA(block, 'OLET', seq));
-  lines.push('');
+  lines.push('OLET', `${INDENT}CENTRE-POINT  ${fmtCoord(block.cp, block.bore, cfg)}`, `${INDENT}BRANCH1-POINT ${fmtCoord(block.bp, block.branchBore || 50, cfg)}`);
+  lines.push(...emitSkey(block), ...emitCA(block, 'OLET', seq), '');
   return lines;
 }
-
 function emitValve(block, seq, cfg) {
   if (!block.ep1 || !block.ep2) return [];
-  const refNo = refFor(block);
-  const lenText = firstLengthText(block, cfg);
-  const lines = [];
+  const refNo = refFor(block), lenText = firstLengthText(block, cfg), lines = [];
   lines.push(...emitMsgSq(['VALVE', lenText ? `LENGTH=${lenText}` : '', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`], cfg));
-  lines.push('VALVE');
-  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`);
-  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`);
-  lines.push(...emitSkey(block));
-  lines.push(...emitCA(block, 'VALVE', seq));
-  lines.push('');
+  lines.push('VALVE', `${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`, `${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`);
+  lines.push(...emitSkey(block), ...emitCA(block, 'VALVE', seq), '');
   return lines;
 }
-
 function emitReducer(block, seq, cfg) {
   if (!block.ep1 || !block.ep2) return [];
-  const refNo = refFor(block);
-  const lenText = firstLengthText(block, cfg);
-  const lines = [];
+  const refNo = refFor(block), lenText = firstLengthText(block, cfg), lines = [];
   lines.push(...emitMsgSq([block.type, lenText ? `LENGTH=${lenText}` : '', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`], cfg));
-  lines.push(block.type);
-  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`);
-  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep2, block.branchBore || block.bore, cfg)}`);
-  lines.push(...emitSkey(block, block.type === 'REDUCER-ECCENTRIC' ? 'REBW' : 'RCBW'));
-  lines.push(...emitCA(block, block.type, seq));
-  lines.push('');
+  lines.push(block.type, `${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`, `${INDENT}END-POINT    ${fmtCoord(block.ep2, block.branchBore || block.bore, cfg)}`);
+  lines.push(...emitSkey(block, block.type === 'REDUCER-ECCENTRIC' ? 'REBW' : 'RCBW'), ...emitCA(block, block.type, seq), '');
   return lines;
 }
-
 function emitSupport(block, seq, cfg) {
   const supportName = cleanText(block.supportName) || cleanText(cfg?.supportMapping?.fallbackName) || cleanText(cfg?.supportDefaultCoor) || 'CA150';
   const rawGuid = cleanText(block.supportGuid);
@@ -224,10 +134,8 @@ function emitSupport(block, seq, cfg) {
   lines.push('');
   return lines;
 }
-
 function emitBlock(block, seq, model, cfg) {
-  if (!block || block.skipReason) return [];
-  if (NON_EMIT_TYPES.has(block.rawType) || NON_EMIT_TYPES.has(block.type)) return [];
+  if (!block || block.skipReason || NON_EMIT_TYPES.has(block.rawType) || NON_EMIT_TYPES.has(block.type)) return [];
   switch (block.type) {
     case 'PIPE': return emitPipe(block, seq, model, cfg);
     case 'FLANGE': return emitFlange(block, seq, cfg);
@@ -241,39 +149,54 @@ function emitBlock(block, seq, model, cfg) {
     default: return [];
   }
 }
-
+function bridgeOriginKey(block) {
+  return cleanText(block?.source?.fromRefNo || block?.fromRefNo || '');
+}
+function buildBridgeGroups(model) {
+  const groups = new Map();
+  for (const bridge of model?.bridgeBlocks || []) {
+    const key = bridgeOriginKey(bridge) || '__unkeyed';
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(bridge);
+  }
+  return groups;
+}
+function shouldSkipOriginalPipe(block, model) {
+  return block?.type === 'PIPE' && Array.isArray(model?.bridgeBlocks) && model.bridgeBlocks.length > 0;
+}
 export function emitPcfModel(model, cfg = {}) {
   const eol = cfg?.windowsLineEndings === false ? '\n' : '\r\n';
   const lines = buildHeader(model, cfg);
   const emittedBlocks = [];
+  const bridgeGroups = buildBridgeGroups(model);
+  const emittedBridgeIds = new Set();
   let seq = 0;
-
-  for (const block of model?.blocks || []) {
-    if (block?.skipReason) continue;
+  const pushBlock = (block) => {
+    if (shouldSkipOriginalPipe(block, model)) return;
     const previewLines = emitBlock(block, seq + 1, model, cfg);
-    if (!previewLines.length) continue;
+    if (!previewLines.length) return;
     seq += 1;
     block.emitSeq = seq;
-    const blockLines = emitBlock(block, seq, model, cfg);
-    lines.push(...blockLines);
-    emittedBlocks.push({
-      id: block.id,
-      type: block.type,
-      rawType: block.rawType,
-      refNo: block.refNo,
-      seqNo: seq,
-      sourceKind: block.sourceKind,
-    });
-  }
-
-  return {
-    pcfText: lines.join(eol),
-    emittedBlocks,
-    meta: {
-      engine: 'common',
-      emittedBy: 'pcf-model-emitter',
-      lineCount: lines.length,
-      blockCount: emittedBlocks.length,
+    lines.push(...emitBlock(block, seq, model, cfg));
+    emittedBlocks.push({ id: block.id, type: block.type, rawType: block.rawType, refNo: block.refNo, seqNo: seq, sourceKind: block.sourceKind });
+  };
+  const pushBridgesFrom = (refNo) => {
+    const list = bridgeGroups.get(cleanText(refNo)) || [];
+    for (const bridge of list) {
+      if (emittedBridgeIds.has(bridge.id)) continue;
+      emittedBridgeIds.add(bridge.id);
+      pushBlock(bridge);
     }
   };
+  for (const block of model?.componentBlocks || []) {
+    pushBlock(block);
+    pushBridgesFrom(block.refNo || block.source?.originalRefNo);
+  }
+  // Safety net for bridges whose fromRefNo was not found in component list.
+  for (const bridge of model?.bridgeBlocks || []) {
+    if (emittedBridgeIds.has(bridge.id)) continue;
+    emittedBridgeIds.add(bridge.id);
+    pushBlock(bridge);
+  }
+  return { pcfText: lines.join(eol), emittedBlocks, meta: { engine: 'common', emittedBy: 'pcf-model-emitter', lineCount: lines.length, blockCount: emittedBlocks.length, bridgeOrdering: 'legacy-origin-after-component' } };
 }

--- a/js/pcf-engine/pcf-model-emitter.js
+++ b/js/pcf-engine/pcf-model-emitter.js
@@ -1,0 +1,279 @@
+/**
+ * pcf-model-emitter.js — Common PCF Builder Phase 2
+ *
+ * Converts canonical Common PCF model blocks into PCF text.
+ */
+
+import { emitCABlock } from './pcf-block-schema.js';
+
+const INDENT = '    ';
+const NON_EMIT_TYPES = new Set(['GASK', 'PCOM', 'MISC', 'WELD', 'ATTA', 'INST']);
+
+function n(value, fallback = 0) {
+  const x = Number(value);
+  return Number.isFinite(x) ? x : fallback;
+}
+
+function cleanText(value) {
+  return String(value ?? '').replace(/=/g, '').trim();
+}
+
+function p(cfg) {
+  return Number.isInteger(cfg?.decimalPrecision) ? cfg.decimalPrecision : 4;
+}
+
+function fmtNum(value, cfg) {
+  return n(value, 0).toFixed(p(cfg));
+}
+
+function fmtCoord(pt, bore, cfg) {
+  return `${fmtNum(pt?.x, cfg)} ${fmtNum(pt?.y, cfg)} ${fmtNum(pt?.z, cfg)} ${fmtNum(bore, cfg)}`;
+}
+
+function emitMsgSq(parts, cfg) {
+  if (cfg?.messageSquareEnabled === false) return [];
+  return ['MESSAGE-SQUARE', `${INDENT}${parts.filter(Boolean).join(', ')}`];
+}
+
+function emitSkey(block, fallback = '') {
+  const skey = cleanText(block?.skey || fallback);
+  return skey ? [`${INDENT}<SKEY> ${skey}`] : [];
+}
+
+function caFor(block) {
+  const ca = { ...(block?.ca || {}) };
+  if (block?.weight != null && block.weight !== '' && !ca['8']) ca['8'] = String(block.weight);
+  return ca;
+}
+
+function refFor(block, fallback = '') {
+  return cleanText(block?.refNo || block?.source?.originalRefNo || fallback);
+}
+
+function lengthAxis(ep1, ep2, cfg) {
+  if (!ep1 || !ep2) return {};
+  const dx = n(ep2.x) - n(ep1.x);
+  const dy = n(ep2.y) - n(ep1.y);
+  const dz = n(ep2.z) - n(ep1.z);
+  const axis = (delta, pos, neg) => Math.abs(delta) < 1e-6 ? '' : (delta > 0 ? pos : neg);
+  return {
+    len1: Math.abs(dx) > 1e-6 ? fmtNum(dx, cfg) : '', axis1: axis(dx, 'EAST', 'WEST'),
+    len2: Math.abs(dy) > 1e-6 ? fmtNum(dy, cfg) : '', axis2: axis(dy, 'NORTH', 'SOUTH'),
+    len3: Math.abs(dz) > 1e-6 ? fmtNum(dz, cfg) : '', axis3: axis(dz, 'UP', 'DOWN'),
+  };
+}
+
+function primaryLengthText(block, cfg) {
+  const la = lengthAxis(block.ep1, block.ep2, cfg);
+  return [
+    la.len1 ? `${la.len1}MM ${la.axis1}` : '',
+    la.len2 ? `${la.len2}MM ${la.axis2}` : '',
+    la.len3 ? `${la.len3}MM ${la.axis3}` : '',
+  ].filter(Boolean).join(' + ');
+}
+
+function firstLengthText(block, cfg) {
+  const la = lengthAxis(block.ep1, block.ep2, cfg);
+  if (la.len1) return `${la.len1}MM ${la.axis1}`;
+  if (la.len2) return `${la.len2}MM ${la.axis2}`;
+  if (la.len3) return `${la.len3}MM ${la.axis3}`;
+  return '';
+}
+
+function buildHeader(model) {
+  const pipelineRef = cleanText(model?.pipelineRef || '');
+  return [
+    'ISOGEN-FILES ISOGEN.FLS',
+    'UNITS-BORE MM',
+    'UNITS-CO-ORDS MM',
+    'UNITS-WEIGHT KGS',
+    'UNITS-BOLT-DIA MM',
+    'UNITS-BOLT-LENGTH MM',
+    `PIPELINE-REFERENCE ${pipelineRef}`,
+    `${INDENT}PROJECT-IDENTIFIER P1`,
+    `${INDENT}AREA A1`,
+    ''
+  ];
+}
+
+function emitCA(block, blockType, seq) {
+  return emitCABlock(caFor(block), blockType, refFor(block), seq);
+}
+
+function emitPipe(block, seq, model, cfg) {
+  if (!block.ep1 || !block.ep2) return [];
+  const refNo = refFor(block);
+  const lenText = primaryLengthText(block, cfg);
+  const lines = [];
+  lines.push(...emitMsgSq(['PIPE', refNo ? `RefNo:=${refNo}` : '', lenText ? `LENGTH=${lenText}` : '', `SeqNo:${seq}`], cfg));
+  lines.push('PIPE');
+  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`);
+  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`);
+  if (model?.pipelineRef) lines.push(`${INDENT}PIPELINE-REFERENCE ${cleanText(model.pipelineRef)}`);
+  lines.push(...emitSkey(block));
+  lines.push(...emitCA(block, 'PIPE', seq));
+  lines.push('');
+  return lines;
+}
+
+function emitFlange(block, seq, cfg) {
+  if (!block.ep1 || !block.ep2) return [];
+  const refNo = refFor(block);
+  const lenText = firstLengthText(block, cfg);
+  const lines = [];
+  lines.push(...emitMsgSq(['FLANGE', lenText ? `LENGTH=${lenText}` : '', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`], cfg));
+  lines.push('FLANGE');
+  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`);
+  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`);
+  lines.push(...emitSkey(block, block.rawType === 'FBLI' ? 'BLFL' : ''));
+  lines.push(...emitCA(block, 'FLANGE', seq));
+  lines.push('');
+  return lines;
+}
+
+function emitBend(block, seq, cfg) {
+  if (!block.ep1 || !block.ep2 || !block.cp) return [];
+  const refNo = refFor(block);
+  const lines = [];
+  lines.push(...emitMsgSq(['BEND', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`], cfg));
+  lines.push('BEND');
+  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`);
+  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`);
+  lines.push(`${INDENT}CENTRE-POINT  ${fmtCoord(block.cp, block.bore, cfg)}`);
+  lines.push(...emitSkey(block));
+  lines.push(`${INDENT}ANGLE ${fmtNum(block.angleDeg ?? 90, cfg)}`);
+  if (block.radius || block.bendRadius) lines.push(`${INDENT}BEND-RADIUS ${fmtNum(block.radius || block.bendRadius, cfg)}`);
+  lines.push(...emitCA(block, 'BEND', seq));
+  lines.push('');
+  return lines;
+}
+
+function emitTee(block, seq, cfg) {
+  if (!block.ep1 || !block.ep2 || !block.cp || !block.bp) return [];
+  const refNo = refFor(block);
+  const brlen = block.brlen ?? block.branchLength ?? '';
+  const lines = [];
+  lines.push(...emitMsgSq(['TEE', brlen !== '' ? `LENGTH=${brlen}MM` : '', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`, brlen !== '' ? `BrLen=${brlen}MM` : ''], cfg));
+  lines.push('TEE');
+  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`);
+  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`);
+  lines.push(`${INDENT}CENTRE-POINT  ${fmtCoord(block.cp, block.bore, cfg)}`);
+  lines.push(`${INDENT}BRANCH1-POINT ${fmtCoord(block.bp, block.branchBore || block.bore, cfg)}`);
+  lines.push(...emitSkey(block));
+  lines.push(...emitCA(block, 'TEE', seq));
+  lines.push('');
+  return lines;
+}
+
+function emitOlet(block, seq, cfg) {
+  if (!block.cp || !block.bp) return [];
+  const refNo = refFor(block);
+  const brlen = block.brlen ?? block.branchLength ?? '';
+  const lines = [];
+  lines.push(...emitMsgSq(['OLET', brlen !== '' ? `BrLen=${brlen}MM` : '', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`], cfg));
+  lines.push('OLET');
+  lines.push(`${INDENT}CENTRE-POINT  ${fmtCoord(block.cp, block.bore, cfg)}`);
+  lines.push(`${INDENT}BRANCH1-POINT ${fmtCoord(block.bp, block.branchBore || 50, cfg)}`);
+  lines.push(...emitSkey(block));
+  lines.push(...emitCA(block, 'OLET', seq));
+  lines.push('');
+  return lines;
+}
+
+function emitValve(block, seq, cfg) {
+  if (!block.ep1 || !block.ep2) return [];
+  const refNo = refFor(block);
+  const lenText = firstLengthText(block, cfg);
+  const lines = [];
+  lines.push(...emitMsgSq(['VALVE', lenText ? `LENGTH=${lenText}` : '', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`], cfg));
+  lines.push('VALVE');
+  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`);
+  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`);
+  lines.push(...emitSkey(block));
+  lines.push(...emitCA(block, 'VALVE', seq));
+  lines.push('');
+  return lines;
+}
+
+function emitReducer(block, seq, cfg) {
+  if (!block.ep1 || !block.ep2) return [];
+  const refNo = refFor(block);
+  const lenText = firstLengthText(block, cfg);
+  const lines = [];
+  lines.push(...emitMsgSq([block.type, lenText ? `LENGTH=${lenText}` : '', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`], cfg));
+  lines.push(block.type);
+  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`);
+  lines.push(`${INDENT}END-POINT    ${fmtCoord(block.ep2, block.branchBore || block.bore, cfg)}`);
+  lines.push(...emitSkey(block, block.type === 'REDUCER-ECCENTRIC' ? 'REBW' : 'RCBW'));
+  lines.push(...emitCA(block, block.type, seq));
+  lines.push('');
+  return lines;
+}
+
+function emitSupport(block, seq, cfg) {
+  const supportName = cleanText(block.supportName) || cleanText(cfg?.supportMapping?.fallbackName) || cleanText(cfg?.supportDefaultCoor) || 'CA150';
+  const rawGuid = cleanText(block.supportGuid);
+  const guidOut = rawGuid ? (rawGuid.startsWith('UCI:') ? rawGuid : `UCI:${rawGuid}`) : '';
+  const lines = [];
+  lines.push(...emitMsgSq(['SUPPORT', `RefNo:=${refFor(block)}`, `SeqNo:${seq}`, supportName, guidOut], cfg));
+  lines.push('SUPPORT');
+  if (block.supportCoor) lines.push(`${INDENT}CO-ORDS    ${fmtCoord(block.supportCoor, 0, cfg)}`);
+  else lines.push(`${INDENT}CO-ORDS    ${cleanText(cfg?.supportDefaultCoor || supportName)}`);
+  lines.push(`${INDENT}<SUPPORT_NAME>    ${supportName}`);
+  if (guidOut) lines.push(`${INDENT}<SUPPORT_GUID>    ${guidOut}`);
+  lines.push('');
+  return lines;
+}
+
+function emitBlock(block, seq, model, cfg) {
+  if (!block || block.skipReason) return [];
+  if (NON_EMIT_TYPES.has(block.rawType) || NON_EMIT_TYPES.has(block.type)) return [];
+  switch (block.type) {
+    case 'PIPE': return emitPipe(block, seq, model, cfg);
+    case 'FLANGE': return emitFlange(block, seq, cfg);
+    case 'BEND': return emitBend(block, seq, cfg);
+    case 'TEE': return emitTee(block, seq, cfg);
+    case 'OLET': return emitOlet(block, seq, cfg);
+    case 'VALVE': return emitValve(block, seq, cfg);
+    case 'REDUCER-CONCENTRIC':
+    case 'REDUCER-ECCENTRIC': return emitReducer(block, seq, cfg);
+    case 'SUPPORT': return emitSupport(block, seq, cfg);
+    default: return [];
+  }
+}
+
+export function emitPcfModel(model, cfg = {}) {
+  const eol = cfg?.windowsLineEndings === false ? '\n' : '\r\n';
+  const lines = buildHeader(model, cfg);
+  const emittedBlocks = [];
+  let seq = 0;
+
+  for (const block of model?.blocks || []) {
+    if (block?.skipReason) continue;
+    const previewLines = emitBlock(block, seq + 1, model, cfg);
+    if (!previewLines.length) continue;
+    seq += 1;
+    block.emitSeq = seq;
+    const blockLines = emitBlock(block, seq, model, cfg);
+    lines.push(...blockLines);
+    emittedBlocks.push({
+      id: block.id,
+      type: block.type,
+      rawType: block.rawType,
+      refNo: block.refNo,
+      seqNo: seq,
+      sourceKind: block.sourceKind,
+    });
+  }
+
+  return {
+    pcfText: lines.join(eol),
+    emittedBlocks,
+    meta: {
+      engine: 'common',
+      emittedBy: 'pcf-model-emitter',
+      lineCount: lines.length,
+      blockCount: emittedBlocks.length,
+    }
+  };
+}

--- a/js/pcf-engine/pcf-model-emitter.js
+++ b/js/pcf-engine/pcf-model-emitter.js
@@ -4,6 +4,8 @@
  * Converts canonical Common PCF model blocks into PCF text.
  * Phase 3B adds bridge ordering parity: bridge PIPE blocks are emitted
  * immediately after their originating component, matching legacy Stage 4.
+ * Phase 3C adds support-on-bridge split parity: supports located on a bridge
+ * split the bridge into pipe segments and are emitted inline.
  */
 
 import { emitCABlock } from './pcf-block-schema.js';
@@ -35,6 +37,8 @@ function caFor(block) {
   return ca;
 }
 function refFor(block, fallback = '') { return cleanText(block?.refNo || block?.source?.originalRefNo || fallback); }
+function vecSub(a, b) { return { x: n(a?.x) - n(b?.x), y: n(a?.y) - n(b?.y), z: n(a?.z) - n(b?.z) }; }
+function vecMag(v) { return Math.sqrt(n(v?.x) * n(v?.x) + n(v?.y) * n(v?.y) + n(v?.z) * n(v?.z)); }
 function lengthAxis(ep1, ep2, cfg) {
   if (!ep1 || !ep2) return {};
   const dx = n(ep2.x) - n(ep1.x), dy = n(ep2.y) - n(ep1.y), dz = n(ep2.z) - n(ep1.z);
@@ -149,9 +153,8 @@ function emitBlock(block, seq, model, cfg) {
     default: return [];
   }
 }
-function bridgeOriginKey(block) {
-  return cleanText(block?.source?.fromRefNo || block?.fromRefNo || '');
-}
+function blockKey(block) { return cleanText(block?.refNo || block?.id || ''); }
+function bridgeOriginKey(block) { return cleanText(block?.source?.fromRefNo || block?.fromRefNo || ''); }
 function buildBridgeGroups(model) {
   const groups = new Map();
   for (const bridge of model?.bridgeBlocks || []) {
@@ -161,31 +164,81 @@ function buildBridgeGroups(model) {
   }
   return groups;
 }
-function shouldSkipOriginalPipe(block, model) {
-  return block?.type === 'PIPE' && Array.isArray(model?.bridgeBlocks) && model.bridgeBlocks.length > 0;
+function supportPoint(block) { return block?.supportCoor || block?.cp || null; }
+function supportsOnBridge(bridge, supportBlocks, cfg) {
+  if (!bridge?.ep1 || !bridge?.ep2) return [];
+  const seg = vecSub(bridge.ep2, bridge.ep1);
+  const segLen = vecMag(seg);
+  if (segLen < 1e-6) return [];
+  const sd = { x: seg.x / segLen, y: seg.y / segLen, z: seg.z / segLen };
+  const tol = Math.max((bridge.bore || 0) * (cfg?.boreTolMultiplier || 0.5), (cfg?.minBoreTol || 25), 1000);
+  const hits = [];
+  for (const sp of supportBlocks || []) {
+    const pt = supportPoint(sp);
+    if (!pt) continue;
+    const tv = vecSub(pt, bridge.ep1);
+    const t = tv.x * sd.x + tv.y * sd.y + tv.z * sd.z;
+    if (t <= 0 || t >= segLen) continue;
+    const snap = { x: bridge.ep1.x + sd.x * t, y: bridge.ep1.y + sd.y * t, z: bridge.ep1.z + sd.z * t };
+    const perpDist = vecMag(vecSub(pt, snap));
+    if (perpDist <= tol) hits.push({ comp: sp, t, snap });
+  }
+  hits.sort((a, b) => a.t - b.t);
+  return hits;
 }
+function shouldSkipOriginalPipe(block, model) { return block?.type === 'PIPE' && Array.isArray(model?.bridgeBlocks) && model.bridgeBlocks.length > 0; }
 export function emitPcfModel(model, cfg = {}) {
   const eol = cfg?.windowsLineEndings === false ? '\n' : '\r\n';
   const lines = buildHeader(model, cfg);
   const emittedBlocks = [];
   const bridgeGroups = buildBridgeGroups(model);
   const emittedBridgeIds = new Set();
+  const inlineSupportKeys = new Set();
+  const supportBlocks = (model?.componentBlocks || []).filter(b => b.type === 'SUPPORT');
+  let splitBridgeCount = 0;
+  let inlineSupportCount = 0;
   let seq = 0;
-  const pushBlock = (block) => {
+  const pushBlock = (block, options = {}) => {
+    if (!options.force && block?.type === 'SUPPORT' && inlineSupportKeys.has(blockKey(block))) return;
     if (shouldSkipOriginalPipe(block, model)) return;
     const previewLines = emitBlock(block, seq + 1, model, cfg);
     if (!previewLines.length) return;
     seq += 1;
     block.emitSeq = seq;
     lines.push(...emitBlock(block, seq, model, cfg));
-    emittedBlocks.push({ id: block.id, type: block.type, rawType: block.rawType, refNo: block.refNo, seqNo: seq, sourceKind: block.sourceKind });
+    emittedBlocks.push({ id: block.id, type: block.type, rawType: block.rawType, refNo: block.refNo, seqNo: seq, sourceKind: block.sourceKind, splitKind: block.splitKind || '' });
+  };
+  const pushBridgeSplit = (bridge, originRefNo) => {
+    const originRef = cleanText(originRefNo || bridgeOriginKey(bridge));
+    const ep1RefNo = originRef ? `${originRef}_bridged` : '';
+    const hits = supportsOnBridge(bridge, supportBlocks, cfg);
+    if (!hits.length) {
+      pushBlock({ ...bridge, refNo: ep1RefNo, splitKind: 'bridge-unsplit' }, { force: true });
+      return;
+    }
+    splitBridgeCount += 1;
+    let cursor = bridge.ep1;
+    let idx = 0;
+    for (const hit of hits) {
+      idx += 1;
+      const supportRef = cleanText(hit.comp.refNo || hit.comp.source?.originalRefNo || `SUPPORT_${idx}`);
+      const segRefNo = `${supportRef}_bridged`;
+      pushBlock({ ...bridge, id: `${bridge.id}:split:${idx}`, ep1: cursor, ep2: hit.snap, refNo: segRefNo, splitKind: 'bridge-to-support' }, { force: true });
+      const supportKey = blockKey(hit.comp);
+      inlineSupportKeys.add(supportKey);
+      inlineSupportCount += 1;
+      pushBlock({ ...hit.comp, supportCoor: hit.snap, splitKind: 'inline-bridge-support' }, { force: true });
+      cursor = hit.snap;
+    }
+    pushBlock({ ...bridge, id: `${bridge.id}:tail`, ep1: cursor, ep2: bridge.ep2, refNo: ep1RefNo, splitKind: 'bridge-tail' }, { force: true });
   };
   const pushBridgesFrom = (refNo) => {
-    const list = bridgeGroups.get(cleanText(refNo)) || [];
+    const key = cleanText(refNo);
+    const list = bridgeGroups.get(key) || [];
     for (const bridge of list) {
       if (emittedBridgeIds.has(bridge.id)) continue;
       emittedBridgeIds.add(bridge.id);
-      pushBlock(bridge);
+      pushBridgeSplit(bridge, key);
     }
   };
   for (const block of model?.componentBlocks || []) {
@@ -196,7 +249,20 @@ export function emitPcfModel(model, cfg = {}) {
   for (const bridge of model?.bridgeBlocks || []) {
     if (emittedBridgeIds.has(bridge.id)) continue;
     emittedBridgeIds.add(bridge.id);
-    pushBlock(bridge);
+    pushBridgeSplit(bridge, bridgeOriginKey(bridge));
   }
-  return { pcfText: lines.join(eol), emittedBlocks, meta: { engine: 'common', emittedBy: 'pcf-model-emitter', lineCount: lines.length, blockCount: emittedBlocks.length, bridgeOrdering: 'legacy-origin-after-component' } };
+  return {
+    pcfText: lines.join(eol),
+    emittedBlocks,
+    meta: {
+      engine: 'common',
+      emittedBy: 'pcf-model-emitter',
+      lineCount: lines.length,
+      blockCount: emittedBlocks.length,
+      bridgeOrdering: 'legacy-origin-after-component',
+      supportBridgeSplit: 'legacy-inline-projection',
+      splitBridgeCount,
+      inlineSupportCount,
+    }
+  };
 }

--- a/js/pcf-engine/pcf-model-emitter.js
+++ b/js/pcf-engine/pcf-model-emitter.js
@@ -6,6 +6,7 @@
  * immediately after their originating component, matching legacy Stage 4.
  * Phase 3C adds support-on-bridge split parity: supports located on a bridge
  * split the bridge into pipe segments and are emitted inline.
+ * Phase 3D aligns message-square/formatting behavior with legacy Stage 4.
  */
 
 import { emitCABlock } from './pcf-block-schema.js';
@@ -87,8 +88,9 @@ function emitBend(block, seq, cfg) {
   const refNo = refFor(block), lines = [];
   lines.push(...emitMsgSq(['BEND', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`], cfg));
   lines.push('BEND', `${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`, `${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`, `${INDENT}CENTRE-POINT  ${fmtCoord(block.cp, block.bore, cfg)}`);
-  lines.push(...emitSkey(block), `${INDENT}ANGLE ${fmtNum(block.angleDeg ?? 90, cfg)}`);
-  if (block.radius || block.bendRadius) lines.push(`${INDENT}BEND-RADIUS ${fmtNum(block.radius || block.bendRadius, cfg)}`);
+  lines.push(...emitSkey(block));
+  // Legacy parity: Stage 4 emits ANGLE 90.0000 only when radius exists and does not emit BEND-RADIUS.
+  if (block.radius || block.bendRadius) lines.push(`${INDENT}ANGLE ${fmtNum(90, cfg)}`);
   lines.push(...emitCA(block, 'BEND', seq), '');
   return lines;
 }
@@ -129,7 +131,8 @@ function emitSupport(block, seq, cfg) {
   const rawGuid = cleanText(block.supportGuid);
   const guidOut = rawGuid ? (rawGuid.startsWith('UCI:') ? rawGuid : `UCI:${rawGuid}`) : '';
   const lines = [];
-  lines.push(...emitMsgSq(['SUPPORT', `RefNo:=${refFor(block)}`, `SeqNo:${seq}`, supportName, guidOut], cfg));
+  lines.push('MESSAGE-SQUARE');
+  lines.push(`${INDENT}SUPPORT, RefNo:=${refFor(block)}, SeqNo:${seq}, ${supportName}, ${guidOut}`);
   lines.push('SUPPORT');
   if (block.supportCoor) lines.push(`${INDENT}CO-ORDS    ${fmtCoord(block.supportCoor, 0, cfg)}`);
   else lines.push(`${INDENT}CO-ORDS    ${cleanText(cfg?.supportDefaultCoor || supportName)}`);
@@ -188,7 +191,7 @@ function supportsOnBridge(bridge, supportBlocks, cfg) {
 }
 function shouldSkipOriginalPipe(block, model) { return block?.type === 'PIPE' && Array.isArray(model?.bridgeBlocks) && model.bridgeBlocks.length > 0; }
 export function emitPcfModel(model, cfg = {}) {
-  const eol = cfg?.windowsLineEndings === false ? '\n' : '\r\n';
+  const eol = cfg?.windowsLineEndings ? '\r\n' : '\n';
   const lines = buildHeader(model, cfg);
   const emittedBlocks = [];
   const bridgeGroups = buildBridgeGroups(model);
@@ -245,7 +248,6 @@ export function emitPcfModel(model, cfg = {}) {
     pushBlock(block);
     pushBridgesFrom(block.refNo || block.source?.originalRefNo);
   }
-  // Safety net for bridges whose fromRefNo was not found in component list.
   for (const bridge of model?.bridgeBlocks || []) {
     if (emittedBridgeIds.has(bridge.id)) continue;
     emittedBridgeIds.add(bridge.id);
@@ -261,6 +263,7 @@ export function emitPcfModel(model, cfg = {}) {
       blockCount: emittedBlocks.length,
       bridgeOrdering: 'legacy-origin-after-component',
       supportBridgeSplit: 'legacy-inline-projection',
+      formattingParity: 'legacy-stage4-v1',
       splitBridgeCount,
       inlineSupportCount,
     }

--- a/js/pcf-engine/pcf-model-emitter.js
+++ b/js/pcf-engine/pcf-model-emitter.js
@@ -1,5 +1,5 @@
 /**
- * pcf-model-emitter.js — Common PCF Builder Phase 2/3
+ * pcf-model-emitter.js — Common PCF Builder Phase 2/3/4
  *
  * Converts canonical Common PCF model blocks into PCF text.
  * Phase 3B adds bridge ordering parity: bridge PIPE blocks are emitted
@@ -7,9 +7,11 @@
  * Phase 3C adds support-on-bridge split parity: supports located on a bridge
  * split the bridge into pipe segments and are emitted inline.
  * Phase 3D aligns message-square/formatting behavior with legacy Stage 4.
+ * Phase 4F uses centralized support mapping for SUPPORT_NAME/GUID.
  */
 
 import { emitCABlock } from './pcf-block-schema.js';
+import { resolveSupportMapping } from './support-mapper.js';
 
 const INDENT = '    ';
 const NON_EMIT_TYPES = new Set(['GASK', 'PCOM', 'MISC', 'WELD', 'ATTA', 'INST']);
@@ -89,7 +91,6 @@ function emitBend(block, seq, cfg) {
   lines.push(...emitMsgSq(['BEND', refNo ? `RefNo:=${refNo}` : '', `SeqNo:${seq}`], cfg));
   lines.push('BEND', `${INDENT}END-POINT    ${fmtCoord(block.ep1, block.bore, cfg)}`, `${INDENT}END-POINT    ${fmtCoord(block.ep2, block.bore, cfg)}`, `${INDENT}CENTRE-POINT  ${fmtCoord(block.cp, block.bore, cfg)}`);
   lines.push(...emitSkey(block));
-  // Legacy parity: Stage 4 emits ANGLE 90.0000 only when radius exists and does not emit BEND-RADIUS.
   if (block.radius || block.bendRadius) lines.push(`${INDENT}ANGLE ${fmtNum(90, cfg)}`);
   lines.push(...emitCA(block, 'BEND', seq), '');
   return lines;
@@ -127,9 +128,9 @@ function emitReducer(block, seq, cfg) {
   return lines;
 }
 function emitSupport(block, seq, cfg) {
-  const supportName = cleanText(block.supportName) || cleanText(cfg?.supportMapping?.fallbackName) || cleanText(cfg?.supportDefaultCoor) || 'CA150';
-  const rawGuid = cleanText(block.supportGuid);
-  const guidOut = rawGuid ? (rawGuid.startsWith('UCI:') ? rawGuid : `UCI:${rawGuid}`) : '';
+  const resolved = resolveSupportMapping(block, cfg);
+  const supportName = resolved.supportName || 'CA150';
+  const guidOut = resolved.supportGuid || '';
   const lines = [];
   lines.push('MESSAGE-SQUARE');
   lines.push(`${INDENT}SUPPORT, RefNo:=${refFor(block)}, SeqNo:${seq}, ${supportName}, ${guidOut}`);
@@ -139,6 +140,7 @@ function emitSupport(block, seq, cfg) {
   lines.push(`${INDENT}<SUPPORT_NAME>    ${supportName}`);
   if (guidOut) lines.push(`${INDENT}<SUPPORT_GUID>    ${guidOut}`);
   lines.push('');
+  block.supportMapping = resolved;
   return lines;
 }
 function emitBlock(block, seq, model, cfg) {
@@ -200,6 +202,7 @@ export function emitPcfModel(model, cfg = {}) {
   const supportBlocks = (model?.componentBlocks || []).filter(b => b.type === 'SUPPORT');
   let splitBridgeCount = 0;
   let inlineSupportCount = 0;
+  let supportMappedCount = 0;
   let seq = 0;
   const pushBlock = (block, options = {}) => {
     if (!options.force && block?.type === 'SUPPORT' && inlineSupportKeys.has(blockKey(block))) return;
@@ -209,7 +212,8 @@ export function emitPcfModel(model, cfg = {}) {
     seq += 1;
     block.emitSeq = seq;
     lines.push(...emitBlock(block, seq, model, cfg));
-    emittedBlocks.push({ id: block.id, type: block.type, rawType: block.rawType, refNo: block.refNo, seqNo: seq, sourceKind: block.sourceKind, splitKind: block.splitKind || '' });
+    if (block.type === 'SUPPORT' && block.supportMapping) supportMappedCount += 1;
+    emittedBlocks.push({ id: block.id, type: block.type, rawType: block.rawType, refNo: block.refNo, seqNo: seq, sourceKind: block.sourceKind, splitKind: block.splitKind || '', supportMapping: block.supportMapping || null });
   };
   const pushBridgeSplit = (bridge, originRefNo) => {
     const originRef = cleanText(originRefNo || bridgeOriginKey(bridge));
@@ -264,8 +268,10 @@ export function emitPcfModel(model, cfg = {}) {
       bridgeOrdering: 'legacy-origin-after-component',
       supportBridgeSplit: 'legacy-inline-projection',
       formattingParity: 'legacy-stage4-v1',
+      supportMapping: 'centralized-support-mapper',
       splitBridgeCount,
       inlineSupportCount,
+      supportMappedCount,
     }
   };
 }

--- a/js/pcf-engine/pcf-output-diff.js
+++ b/js/pcf-engine/pcf-output-diff.js
@@ -1,0 +1,130 @@
+/**
+ * pcf-output-diff.js — Legacy/Common PCF output comparator
+ *
+ * Parses PCF text into normalized blocks and compares block-by-block.
+ */
+
+const COMPONENT_KEYWORDS = new Set(['PIPE','FLANGE','BEND','TEE','OLET','VALVE','REDUCER-CONCENTRIC','REDUCER-ECCENTRIC','SUPPORT','MISC-COMPONENT']);
+function cleanLine(line) { return String(line ?? '').replace(/\r/g, '').trimEnd(); }
+function normText(v) { return String(v ?? '').replace(/\s+/g, ' ').trim(); }
+function num(v) { const n = Number.parseFloat(String(v ?? '').trim()); return Number.isFinite(n) ? n : null; }
+function parseCoordLine(line) {
+  const parts = normText(line).split(/\s+/);
+  const values = parts.slice(1).map(num);
+  if (values.length < 4 || values.some(v => v == null)) return null;
+  return { x: values[0], y: values[1], z: values[2], bore: values[3] };
+}
+function parseCA(line) {
+  const m = normText(line).match(/^COMPONENT-ATTRIBUTE(\d+)\s+(.+)$/i);
+  if (!m) return null;
+  return { slot: m[1], value: normText(m[2]) };
+}
+function parseBlockAttributes(lines) {
+  const out = { endpoints: [], centrePoint: null, branchPoint: null, coOrds: null, skey: '', supportName: '', supportGuid: '', angle: '', bendRadius: '', ca: {}, rawAttributes: [] };
+  for (const raw of lines) {
+    const line = cleanLine(raw).trim();
+    if (!line) continue;
+    out.rawAttributes.push(line);
+    if (line.startsWith('END-POINT')) { const c = parseCoordLine(line); if (c) out.endpoints.push(c); continue; }
+    if (line.startsWith('CENTRE-POINT')) { out.centrePoint = parseCoordLine(line); continue; }
+    if (line.startsWith('BRANCH1-POINT')) { out.branchPoint = parseCoordLine(line); continue; }
+    if (line.startsWith('CO-ORDS')) { out.coOrds = parseCoordLine(line) || normText(line.replace(/^CO-ORDS/i, '')); continue; }
+    if (line.startsWith('<SKEY>')) { out.skey = normText(line.replace(/^<SKEY>/i, '')); continue; }
+    if (line.startsWith('<SUPPORT_NAME>')) { out.supportName = normText(line.replace(/^<SUPPORT_NAME>/i, '')); continue; }
+    if (line.startsWith('<SUPPORT_GUID>')) { out.supportGuid = normText(line.replace(/^<SUPPORT_GUID>/i, '')); continue; }
+    if (line.startsWith('ANGLE')) { out.angle = normText(line.replace(/^ANGLE/i, '')); continue; }
+    if (line.startsWith('BEND-RADIUS')) { out.bendRadius = normText(line.replace(/^BEND-RADIUS/i, '')); continue; }
+    const ca = parseCA(line);
+    if (ca) { out.ca[ca.slot] = ca.value; continue; }
+  }
+  return out;
+}
+export function parsePcfBlocks(pcfText) {
+  const lines = String(pcfText || '').split(/\r?\n/);
+  const blocks = [];
+  let pendingMessage = [];
+  let current = null;
+  const flush = () => {
+    if (!current) return;
+    const attrs = parseBlockAttributes(current.attrLines);
+    blocks.push({ type: current.type, messageSquare: current.messageSquare, attrLines: current.attrLines, ...attrs, refNo: attrs.ca['97'] || '', seqNo: attrs.ca['98'] || '' });
+    current = null;
+  };
+  for (let i = 0; i < lines.length; i++) {
+    const raw = cleanLine(lines[i]);
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    if (trimmed === 'MESSAGE-SQUARE') {
+      pendingMessage = [];
+      const next = cleanLine(lines[i + 1] || '').trim();
+      if (next && !COMPONENT_KEYWORDS.has(next)) { pendingMessage.push(next); i += 1; }
+      continue;
+    }
+    if (COMPONENT_KEYWORDS.has(trimmed)) {
+      flush();
+      current = { type: trimmed, messageSquare: pendingMessage.join('\n'), attrLines: [] };
+      pendingMessage = [];
+      continue;
+    }
+    if (current) current.attrLines.push(trimmed);
+  }
+  flush();
+  return blocks;
+}
+function approxEqual(a, b, tol) {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  return Math.abs(Number(a) - Number(b)) <= tol;
+}
+function compareCoord(path, a, b, diffs, tol) {
+  if (!a && !b) return;
+  if (!a || !b || typeof a !== 'object' || typeof b !== 'object') {
+    diffs.push({ severity: 'critical', path, legacy: a, common: b, message: `${path} presence/type differs` });
+    return;
+  }
+  for (const k of ['x','y','z','bore']) {
+    if (!approxEqual(a[k], b[k], tol.coord)) diffs.push({ severity: 'critical', path: `${path}.${k}`, legacy: a[k], common: b[k], message: `${path}.${k} differs beyond tolerance ${tol.coord}` });
+  }
+}
+function compareCA(blockPath, aCa, bCa, diffs) {
+  const slots = new Set([...Object.keys(aCa || {}), ...Object.keys(bCa || {})]);
+  for (const slot of [...slots].sort((a, b) => Number(a) - Number(b))) {
+    const a = normText(aCa?.[slot]);
+    const b = normText(bCa?.[slot]);
+    if (a !== b) diffs.push({ severity: ['97','98'].includes(slot) ? 'critical' : 'major', path: `${blockPath}.CA${slot}`, legacy: a, common: b, message: `CA${slot} differs` });
+  }
+}
+function compareEndpoints(blockPath, a, b, diffs, tol) {
+  const max = Math.max(a.endpoints.length, b.endpoints.length);
+  if (a.endpoints.length !== b.endpoints.length) diffs.push({ severity: 'critical', path: `${blockPath}.END-POINT.count`, legacy: a.endpoints.length, common: b.endpoints.length, message: 'END-POINT count differs' });
+  for (let i = 0; i < max; i++) compareCoord(`${blockPath}.END-POINT[${i}]`, a.endpoints[i], b.endpoints[i], diffs, tol);
+}
+function compareBlock(index, legacy, common, tol) {
+  const diffs = [];
+  const path = `block[${index}]`;
+  if (!legacy || !common) { diffs.push({ severity: 'critical', path, legacy: legacy?.type || null, common: common?.type || null, message: 'Block missing in one output' }); return diffs; }
+  if (legacy.type !== common.type) diffs.push({ severity: 'critical', path: `${path}.type`, legacy: legacy.type, common: common.type, message: 'Block type differs' });
+  compareEndpoints(path, legacy, common, diffs, tol);
+  compareCoord(`${path}.CENTRE-POINT`, legacy.centrePoint, common.centrePoint, diffs, tol);
+  compareCoord(`${path}.BRANCH1-POINT`, legacy.branchPoint, common.branchPoint, diffs, tol);
+  if (typeof legacy.coOrds === 'object' || typeof common.coOrds === 'object') compareCoord(`${path}.CO-ORDS`, legacy.coOrds, common.coOrds, diffs, tol);
+  else if (normText(legacy.coOrds) !== normText(common.coOrds)) diffs.push({ severity: 'major', path: `${path}.CO-ORDS`, legacy: legacy.coOrds, common: common.coOrds, message: 'CO-ORDS differs' });
+  for (const key of ['skey','supportName','supportGuid','angle','bendRadius']) {
+    const a = normText(legacy[key]);
+    const b = normText(common[key]);
+    if (a !== b) diffs.push({ severity: key === 'skey' ? 'major' : 'minor', path: `${path}.${key}`, legacy: a, common: b, message: `${key} differs` });
+  }
+  compareCA(path, legacy.ca, common.ca, diffs);
+  return diffs;
+}
+export function diffPcfOutputs(legacyText, commonText, options = {}) {
+  const tol = { coord: Number(options.coordTolerance ?? 0.001) };
+  const legacyBlocks = parsePcfBlocks(legacyText);
+  const commonBlocks = parsePcfBlocks(commonText);
+  const diffs = [];
+  if (legacyBlocks.length !== commonBlocks.length) diffs.push({ severity: 'critical', path: 'blocks.count', legacy: legacyBlocks.length, common: commonBlocks.length, message: 'Block count differs' });
+  const max = Math.max(legacyBlocks.length, commonBlocks.length);
+  for (let i = 0; i < max; i++) diffs.push(...compareBlock(i, legacyBlocks[i], commonBlocks[i], tol));
+  const summary = { legacyBlockCount: legacyBlocks.length, commonBlockCount: commonBlocks.length, total: diffs.length, critical: diffs.filter(d => d.severity === 'critical').length, major: diffs.filter(d => d.severity === 'major').length, minor: diffs.filter(d => d.severity === 'minor').length };
+  return { summary, diffs, legacyBlocks, commonBlocks, pass: summary.critical === 0 && summary.major === 0 };
+}

--- a/js/pcf-engine/smart-row-normalizer.js
+++ b/js/pcf-engine/smart-row-normalizer.js
@@ -1,0 +1,181 @@
+/**
+ * smart-row-normalizer.js — Phase 4A Smart Parser foundation
+ *
+ * Normalizes arbitrary imported rows into a canonical PCF row shape.
+ * This module does not mutate the existing Stage 1 pipeline yet; Phase 4G will
+ * wire it into Common Builder / import flow.
+ */
+
+import { CANONICAL_COLUMNS, mapHeaders } from './column-alias-registry.js';
+
+function clean(value) {
+  return String(value ?? '').trim();
+}
+
+function num(value) {
+  const s = clean(value).replace(/,/g, '');
+  if (!s) return null;
+  const m = s.match(/-?\d+(?:\.\d+)?/);
+  if (!m) return null;
+  const n = Number.parseFloat(m[0]);
+  return Number.isFinite(n) ? n : null;
+}
+
+function first(row, keys) {
+  for (const k of keys || []) {
+    if (k && row?.[k] != null && clean(row[k]) !== '') return row[k];
+  }
+  return '';
+}
+
+function getByCanonical(row, headerMap, canonical) {
+  const source = headerMap?.[canonical];
+  if (source && row?.[source] != null) return row[source];
+  if (row?.[canonical] != null) return row[canonical];
+  return '';
+}
+
+function parseCoordTriplet(value) {
+  if (value && typeof value === 'object' && ['x', 'y', 'z'].some(k => value[k] != null)) {
+    const x = num(value.x), y = num(value.y), z = num(value.z);
+    return [x, y, z].every(v => v != null) ? { x, y, z } : null;
+  }
+  const s = clean(value);
+  if (!s) return null;
+  const parts = s.match(/-?\d+(?:\.\d+)?/g);
+  if (!parts || parts.length < 3) return null;
+  const [x, y, z] = parts.slice(0, 3).map(Number.parseFloat);
+  return [x, y, z].every(Number.isFinite) ? { x, y, z } : null;
+}
+
+function splitCoord(row, prefix) {
+  const variants = [
+    [`${prefix} X`, `${prefix} Y`, `${prefix} Z`],
+    [`${prefix}_X`, `${prefix}_Y`, `${prefix}_Z`],
+    [`${prefix}.x`, `${prefix}.y`, `${prefix}.z`],
+    [`${prefix} EAST`, `${prefix} NORTH`, `${prefix} UP`],
+  ];
+  for (const [kx, ky, kz] of variants) {
+    const x = num(row?.[kx]);
+    const y = num(row?.[ky]);
+    const z = num(row?.[kz]);
+    if ([x, y, z].every(v => v != null)) return { x, y, z };
+  }
+  return null;
+}
+
+function coordFrom(row, headerMap, canonical, splitPrefix) {
+  return parseCoordTriplet(getByCanonical(row, headerMap, canonical)) || splitCoord(row, splitPrefix);
+}
+
+function caValue(row, headerMap, n) {
+  return clean(getByCanonical(row, headerMap, `CA${n}`));
+}
+
+function normalizeType(value) {
+  return clean(value).toUpperCase();
+}
+
+function fallbackRef(row, headerMap, rowIndex, pipelineRef) {
+  const explicit = clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.REF_NO));
+  if (explicit) return explicit;
+  const seq = clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.CSV_SEQ_NO)) || String(rowIndex + 1);
+  return pipelineRef ? `${pipelineRef}_${seq}` : seq;
+}
+
+export function normalizeSmartRow(row, options = {}) {
+  const headerMap = options.headerMap || {};
+  const rowIndex = Number(options.rowIndex ?? 0);
+  const pipelineRef = clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.PIPELINE_REFERENCE)) || clean(options.pipelineRef);
+  const refNo = fallbackRef(row, headerMap, rowIndex, pipelineRef);
+  const csvSeqNo = clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.CSV_SEQ_NO)) || String(rowIndex + 1);
+
+  const ca = {};
+  for (let i = 1; i <= 10; i++) {
+    const v = caValue(row, headerMap, i);
+    if (v) ca[String(i)] = v;
+  }
+
+  const ca97 = clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.CA97)) || refNo;
+  const ca98 = clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.CA98)) || csvSeqNo;
+
+  const normalized = {
+    rowIndex,
+    rowNumber: clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.ROW)) || String(rowIndex + 1),
+    csvSeqNo,
+    type: normalizeType(getByCanonical(row, headerMap, CANONICAL_COLUMNS.TYPE)),
+    text: clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.TEXT)),
+    pipelineRef,
+    refNo,
+    bore: num(getByCanonical(row, headerMap, CANONICAL_COLUMNS.BORE)),
+    branchBore: num(getByCanonical(row, headerMap, CANONICAL_COLUMNS.BRANCH_BORE)),
+    ep1: coordFrom(row, headerMap, CANONICAL_COLUMNS.EP1_COORDS, 'EP1'),
+    ep2: coordFrom(row, headerMap, CANONICAL_COLUMNS.EP2_COORDS, 'EP2'),
+    cp: coordFrom(row, headerMap, CANONICAL_COLUMNS.CP_COORDS, 'CP'),
+    bp: coordFrom(row, headerMap, CANONICAL_COLUMNS.BP_COORDS, 'BP'),
+    skey: clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.SKEY)),
+    supportCoor: coordFrom(row, headerMap, CANONICAL_COLUMNS.SUPPORT_COOR, 'SUPPORT COOR'),
+    supportGuid: clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.SUPPORT_GUID)),
+    supportName: clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.SUPPORT_NAME)),
+    ca,
+    ca97,
+    ca98,
+    fixingAction: clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.FIXING_ACTION)),
+    len1: num(getByCanonical(row, headerMap, CANONICAL_COLUMNS.LEN1)),
+    axis1: clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.AXIS1)),
+    len2: num(getByCanonical(row, headerMap, CANONICAL_COLUMNS.LEN2)),
+    axis2: clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.AXIS2)),
+    len3: num(getByCanonical(row, headerMap, CANONICAL_COLUMNS.LEN3)),
+    axis3: clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.AXIS3)),
+    brlen: num(getByCanonical(row, headerMap, CANONICAL_COLUMNS.BRLEN)),
+    deltaX: num(getByCanonical(row, headerMap, CANONICAL_COLUMNS.DELTA_X)),
+    deltaY: num(getByCanonical(row, headerMap, CANONICAL_COLUMNS.DELTA_Y)),
+    deltaZ: num(getByCanonical(row, headerMap, CANONICAL_COLUMNS.DELTA_Z)),
+    diameter: num(getByCanonical(row, headerMap, CANONICAL_COLUMNS.DIAMETER)),
+    wallThick: clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.WALL_THICK)),
+    bendPtr: num(getByCanonical(row, headerMap, CANONICAL_COLUMNS.BEND_PTR)),
+    rigidPtr: num(getByCanonical(row, headerMap, CANONICAL_COLUMNS.RIGID_PTR)),
+    intPtr: num(getByCanonical(row, headerMap, CANONICAL_COLUMNS.INT_PTR)),
+    raw: row,
+    trace: {
+      headerMap,
+      fallbacks: {
+        ca97: ca97 === refNo && !clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.CA97)) ? 'REF NO. fallback' : '',
+        ca98: ca98 === csvSeqNo && !clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.CA98)) ? 'CSV SEQ NO fallback' : '',
+        refNo: !clean(getByCanonical(row, headerMap, CANONICAL_COLUMNS.REF_NO)) ? 'SEQ/pipeline fallback' : '',
+      }
+    }
+  };
+
+  // Calculated column seed values that are safe at normalization time.
+  if (normalized.diameter == null && normalized.bore != null) normalized.diameter = normalized.bore;
+  if (!normalized.wallThick && normalized.ca['4']) normalized.wallThick = normalized.ca['4'];
+
+  return normalized;
+}
+
+export function normalizeSmartRows(rows = [], options = {}) {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const headers = options.headers || Object.keys(safeRows[0] || {});
+  const mapping = options.headerMap ? { map: options.headerMap, diagnostics: [] } : mapHeaders(headers, options);
+  const out = safeRows.map((row, i) => normalizeSmartRow(row, { ...options, headerMap: mapping.map, rowIndex: i }));
+  return {
+    rows: out,
+    headerMap: mapping.map,
+    diagnostics: mapping.diagnostics,
+    summary: {
+      inputRows: safeRows.length,
+      outputRows: out.length,
+      matchedHeaders: Object.keys(mapping.map).length,
+      unmatchedHeaderMessages: mapping.diagnostics.filter(d => d.severity === 'info').length,
+      duplicateHeaderMessages: mapping.diagnostics.filter(d => d.severity === 'warning').length,
+    }
+  };
+}
+
+try {
+  if (typeof window !== 'undefined') {
+    window.normalizeSmartPcfRows = normalizeSmartRows;
+    window.normalizeSmartPcfRow = normalizeSmartRow;
+  }
+} catch (_) {}

--- a/js/pcf-engine/support-mapper.js
+++ b/js/pcf-engine/support-mapper.js
@@ -1,0 +1,211 @@
+/**
+ * support-mapper.js — Phase 4F centralized support mapping
+ *
+ * Responsibilities:
+ * - Derive <SUPPORT_NAME> from friction/gap/config mapping blocks.
+ * - Derive <SUPPORT_GUID> with mandatory UCI: prefix.
+ * - Keep SUPPORT output data free from CA attributes.
+ * - Provide deterministic diagnostics and browser helpers.
+ */
+
+import { getRayConfig } from '../ray-concept/rc-config.js';
+
+const DEFAULT_SUPPORT_MAPPING = Object.freeze({
+  guidPrefix: 'UCI:',
+  fallbackName: 'CA150',
+  blocks: [
+    { id: 1, frictionMatch: ['', '0.3'], gapCondition: 'empty', name: 'CA150', desc: 'Rest / Anchor' },
+    { id: 2, frictionMatch: ['0.15'], gapCondition: 'any', name: 'CA100', desc: 'Guide' },
+    { id: 3, frictionMatch: ['0.3'], gapCondition: '>0', name: 'CA150', desc: 'Rest with Gap' },
+  ],
+});
+
+function clean(value) {
+  return String(value ?? '').trim();
+}
+
+function n(value, fallback = null) {
+  if (value == null || value === '') return fallback;
+  const x = Number(value);
+  return Number.isFinite(x) ? x : fallback;
+}
+
+function normNumberText(value) {
+  const raw = clean(value);
+  if (!raw) return '';
+  const num = n(raw);
+  return num == null ? raw : String(num);
+}
+
+function resolveConfig(cfg = null) {
+  const live = cfg || getRayConfig();
+  const input = live?.supportMapping || {};
+  return {
+    ...DEFAULT_SUPPORT_MAPPING,
+    ...input,
+    guidPrefix: clean(input.guidPrefix || DEFAULT_SUPPORT_MAPPING.guidPrefix) || 'UCI:',
+    fallbackName: clean(input.fallbackName || DEFAULT_SUPPORT_MAPPING.fallbackName) || 'CA150',
+    blocks: Array.isArray(input.blocks) && input.blocks.length ? input.blocks : DEFAULT_SUPPORT_MAPPING.blocks,
+  };
+}
+
+function isGapEmpty(value) {
+  const s = clean(value).toLowerCase();
+  return !s || s === '-' || s === 'null' || s === 'na' || s === 'n/a';
+}
+
+function gapMatches(gap, condition) {
+  const cond = clean(condition).toLowerCase();
+  if (!cond || cond === 'any') return true;
+  if (cond === 'empty') return isGapEmpty(gap);
+  if (cond === '>0' || cond === 'positive') {
+    const g = n(gap, 0);
+    return g > 0;
+  }
+  if (cond === '=0' || cond === 'zero') {
+    const g = n(gap, 0);
+    return g === 0;
+  }
+  return false;
+}
+
+function frictionMatches(friction, matches = []) {
+  const f = normNumberText(friction);
+  const list = Array.isArray(matches) ? matches : [matches];
+  return list.some(m => normNumberText(m) === f);
+}
+
+function candidateGuidValue(row = {}) {
+  return clean(
+    row.supportGuid ||
+    row.SUPPORT_GUID ||
+    row['SUPPORT GUID'] ||
+    row.guid ||
+    row.GUID ||
+    row.nodeName ||
+    row.NodeName ||
+    row['Node Name'] ||
+    row.refNo ||
+    row.ca97 ||
+    row.csvSeqNo ||
+    ''
+  );
+}
+
+function candidateSupportName(row = {}) {
+  return clean(row.supportName || row.SUPPORT_NAME || row['SUPPORT NAME'] || row.supportType || row.SupportType || '');
+}
+
+function candidateFriction(row = {}) {
+  return clean(row.friction ?? row.Friction ?? row.FRICTION ?? row['Friction'] ?? row.ca5 ?? row.CA5 ?? '');
+}
+
+function candidateGap(row = {}) {
+  return clean(row.gap ?? row.Gap ?? row.GAP ?? row['Gap'] ?? row.ca6 ?? row.CA6 ?? '');
+}
+
+export function normalizeSupportGuid(rawGuid, cfg = null) {
+  const mapping = resolveConfig(cfg);
+  const prefix = mapping.guidPrefix || 'UCI:';
+  let raw = clean(rawGuid);
+  if (!raw) return '';
+  raw = raw.replace(/^UCI:/i, '');
+  return `${prefix}${raw}`;
+}
+
+export function resolveSupportMapping(row = {}, cfg = null) {
+  const mapping = resolveConfig(cfg);
+  const diagnostics = [];
+  const explicitName = candidateSupportName(row);
+  const friction = candidateFriction(row);
+  const gap = candidateGap(row);
+  const rawGuid = candidateGuidValue(row);
+
+  let name = explicitName;
+  let source = explicitName ? 'explicit-support-name' : '';
+  let matchedBlock = null;
+
+  if (!name) {
+    for (const block of mapping.blocks || []) {
+      if (frictionMatches(friction, block.frictionMatch) && gapMatches(gap, block.gapCondition)) {
+        name = clean(block.name);
+        source = 'support-mapping-block';
+        matchedBlock = block;
+        break;
+      }
+    }
+  }
+
+  if (!name) {
+    name = mapping.fallbackName;
+    source = 'fallback-name';
+    diagnostics.push({ severity: 'warning', code: 'SUPPORT-NAME-FALLBACK', message: 'No support mapping block matched; fallback name used.' });
+  }
+
+  const guid = normalizeSupportGuid(rawGuid, mapping);
+  if (!guid) {
+    diagnostics.push({ severity: 'warning', code: 'SUPPORT-GUID-MISSING', message: 'Support GUID source is blank; <SUPPORT_GUID> will be omitted.' });
+  }
+
+  return {
+    supportName: name,
+    supportGuid: guid,
+    source,
+    matchedBlockId: matchedBlock?.id ?? null,
+    matchedBlockDesc: matchedBlock?.desc || '',
+    friction,
+    gap,
+    diagnostics,
+    config: {
+      guidPrefix: mapping.guidPrefix,
+      fallbackName: mapping.fallbackName,
+    },
+  };
+}
+
+export function applySupportMapping(row = {}, cfg = null) {
+  const resolved = resolveSupportMapping(row, cfg);
+  const cleaned = { ...row };
+
+  // SUPPORT must not carry CA attributes into the SUPPORT PCF block.
+  if (cleaned.ca && typeof cleaned.ca === 'object') cleaned.ca = {};
+  for (let i = 1; i <= 10; i++) {
+    delete cleaned[`ca${i}`];
+    delete cleaned[`CA${i}`];
+    delete cleaned[`CA ${i}`];
+  }
+
+  return {
+    ...cleaned,
+    supportName: resolved.supportName,
+    supportGuid: resolved.supportGuid,
+    supportMapping: resolved,
+  };
+}
+
+export function applySupportMappings(rows = [], cfg = null) {
+  const out = (Array.isArray(rows) ? rows : []).map(row => {
+    const t = clean(row?.type || row?.rawType || row?.Type).toUpperCase();
+    return t === 'SUPPORT' ? applySupportMapping(row, cfg) : row;
+  });
+
+  return {
+    rows: out,
+    summary: {
+      inputRows: Array.isArray(rows) ? rows.length : 0,
+      supportRows: out.filter(r => clean(r?.type || r?.rawType || r?.Type).toUpperCase() === 'SUPPORT').length,
+      mapped: out.filter(r => r.supportMapping).length,
+      guidMissing: out.filter(r => (r.supportMapping?.diagnostics || []).some(d => d.code === 'SUPPORT-GUID-MISSING')).length,
+      fallbackNameUsed: out.filter(r => r.supportMapping?.source === 'fallback-name').length,
+    }
+  };
+}
+
+try {
+  if (typeof window !== 'undefined') {
+    window.resolvePcfSupportMapping = resolveSupportMapping;
+    window.applyPcfSupportMapping = applySupportMapping;
+    window.applyPcfSupportMappings = applySupportMappings;
+    window.normalizePcfSupportGuid = normalizeSupportGuid;
+  }
+} catch (_) {}

--- a/js/pcf-engine/validators/asme-table-validator.js
+++ b/js/pcf-engine/validators/asme-table-validator.js
@@ -1,0 +1,92 @@
+/**
+ * asme-table-validator.js — Phase 5D ASME/master table certification
+ *
+ * Validates existing in-app ASME/master tables and BRLEN priority behavior.
+ * Does not duplicate ASME data; uses fallbackcontract/masterTableService.
+ */
+
+import { getTeeBrlen, getOletBrlen } from '../../services/fallbackcontract.js';
+import { resolveBrlen } from '../brlen-resolver.js';
+
+function clean(v) { return String(v ?? '').trim(); }
+function n(v, fallback = null) { if (v == null || v === '') return fallback; const x = Number(v); return Number.isFinite(x) ? x : fallback; }
+function issue(severity, code, message, extra = {}) { return { phase:'5D', validator:'asme-table-validator', severity, code, message, ...extra }; }
+function approx(a,b,tol){ return Math.abs(Number(a)-Number(b)) <= tol; }
+
+export function validateAsmeTables(options = {}) {
+  const tol = Number(options.tolerance ?? 0.001);
+  const diagnostics = [];
+
+  const cases = [
+    { name: 'Equal Tee DN400', kind: 'tee', header: 400, branch: 400, expected: 305 },
+    { name: 'Reducing Tee 16x16x12', kind: 'tee', header: 400, branch: 300, expected: 295 },
+    { name: 'Weldolet 10x4', kind: 'olet', header: 250, branch: 100, expected: 231.75 },
+  ];
+
+  for (const c of cases) {
+    const actual = c.kind === 'tee' ? getTeeBrlen(c.header, c.branch) : getOletBrlen(c.header, c.branch);
+    if (actual == null) {
+      diagnostics.push(issue('error', 'ASME-LOOKUP-MISSING', `${c.name} lookup returned null.`, c));
+    } else if (!approx(actual, c.expected, tol)) {
+      diagnostics.push(issue('error', 'ASME-LOOKUP-MISMATCH', `${c.name} lookup mismatch.`, { ...c, actual }));
+    }
+  }
+
+  return {
+    pass: diagnostics.filter(d => d.severity === 'error').length === 0,
+    diagnostics,
+    summary: {
+      cases: cases.length,
+      errors: diagnostics.filter(d => d.severity === 'error').length,
+      warnings: diagnostics.filter(d => d.severity === 'warning').length,
+    },
+  };
+}
+
+export function validateBrlenPriority(options = {}) {
+  const tol = Number(options.tolerance ?? 0.001);
+  const diagnostics = [];
+
+  const direct = resolveBrlen({ type:'TEE', bore:400, branchBore:400, brlen:123 });
+  if (direct.brlen !== 123 || direct.source !== 'direct-data-table') diagnostics.push(issue('error','BRLEN-PRIORITY-DIRECT','Direct BRLEN must win over table lookup.',{actual:direct}));
+
+  const geom = resolveBrlen({ type:'TEE', bore:400, branchBore:400, cp:{x:0,y:0,z:0}, bp:{x:0,y:305,z:0} });
+  if (!approx(geom.brlen,305,tol) || geom.source !== 'calculated-bp-minus-cp') diagnostics.push(issue('error','BRLEN-PRIORITY-GEOMETRY','BP−CP magnitude must win over table lookup when direct BRLEN is absent.',{actual:geom}));
+
+  const table = resolveBrlen({ type:'TEE', bore:400, branchBore:300 });
+  if (!approx(table.brlen,295,tol)) diagnostics.push(issue('error','BRLEN-PRIORITY-TEE-TABLE','Reducing tee table fallback should resolve 400/300 to 295.',{actual:table}));
+
+  const olet = resolveBrlen({ type:'OLET', bore:250, branchBore:100 });
+  if (!approx(olet.brlen,231.75,tol)) diagnostics.push(issue('error','BRLEN-PRIORITY-OLET-TABLE','OLET table fallback should use A + 0.5 × Header OD.',{actual:olet}));
+
+  const missing = resolveBrlen({ type:'TEE', bore:999, branchBore:777 });
+  if (missing.complete !== false) diagnostics.push(issue('error','BRLEN-PRIORITY-INCOMPLETE','Unmatched BRLEN should flag incomplete, not guess.',{actual:missing}));
+
+  return {
+    pass: diagnostics.filter(d => d.severity === 'error').length === 0,
+    diagnostics,
+    summary: {
+      cases: 5,
+      errors: diagnostics.filter(d => d.severity === 'error').length,
+      warnings: diagnostics.filter(d => d.severity === 'warning').length,
+    },
+  };
+}
+
+export function validateAsmeCertification(options = {}) {
+  const tables = validateAsmeTables(options);
+  const priority = validateBrlenPriority(options);
+  const diagnostics = [...tables.diagnostics, ...priority.diagnostics];
+  return {
+    pass: diagnostics.filter(d => d.severity === 'error').length === 0,
+    diagnostics,
+    summary: {
+      tableErrors: tables.summary.errors,
+      priorityErrors: priority.summary.errors,
+      errors: diagnostics.filter(d => d.severity === 'error').length,
+      warnings: diagnostics.filter(d => d.severity === 'warning').length,
+    },
+  };
+}
+
+try { if (typeof window !== 'undefined') { window.validatePcfAsmeTables = validateAsmeTables; window.validatePcfBrlenPriority = validateBrlenPriority; window.validatePcfAsmeCertification = validateAsmeCertification; } } catch (_) {}

--- a/js/pcf-engine/validators/fallback-validator.js
+++ b/js/pcf-engine/validators/fallback-validator.js
@@ -1,0 +1,76 @@
+/**
+ * fallback-validator.js — Phase 5C fallback validation
+ *
+ * Validates fallback provenance/result rules:
+ * - TEE CP midpoint fallback
+ * - BEND CP corner fallback, not midpoint
+ * - OLET CP/BP fallback diagnostics
+ * - CP bore = EP/header bore
+ * - CA97 / CA98 fallback chains
+ * - Branch bore fallback: TEE=header bore, OLET=50 mm
+ */
+
+function clean(v) { return String(v ?? '').trim(); }
+function n(v, fallback = null) { if (v == null || v === '') return fallback; const x = Number(v); return Number.isFinite(x) ? x : fallback; }
+function point(p) { if (!p || typeof p !== 'object') return null; const x=n(p.x), y=n(p.y), z=n(p.z); return [x,y,z].every(v=>v!=null) ? {x,y,z} : null; }
+function approx(a,b,tol){ if(a==null&&b==null)return true; if(a==null||b==null)return false; return Math.abs(Number(a)-Number(b))<=tol; }
+function typeOf(row){ return clean(row?.type || row?.rawType).toUpperCase(); }
+function midpoint(a,b){ const p1=point(a), p2=point(b); if(!p1||!p2)return null; return {x:(p1.x+p2.x)/2,y:(p1.y+p2.y)/2,z:(p1.z+p2.z)/2}; }
+function dist(a,b){ const p1=point(a), p2=point(b); if(!p1||!p2)return null; const dx=p1.x-p2.x,dy=p1.y-p2.y,dz=p1.z-p2.z; return Math.sqrt(dx*dx+dy*dy+dz*dz); }
+function issue(severity, code, row, message, extra={}){ return { phase:'5C', validator:'fallback-validator', severity, code, rowIndex: row?.rowIndex ?? null, refNo: row?.refNo || row?.ca97 || '', type:typeOf(row), message, ...extra }; }
+function hasDiag(row, codePrefix){ return (row?.cpBpFallbackDiagnostics || row?.fallbackDiagnostics || []).some(d => clean(d.code).startsWith(codePrefix)); }
+
+export function validateFallbackRow(row, options = {}) {
+  const tol = Number(options.tolerance ?? 0.001);
+  const diagnostics = [];
+  const t = typeOf(row);
+
+  if (t === 'TEE') {
+    if (point(row.ep1) && point(row.ep2) && point(row.cp)) {
+      const mp = midpoint(row.ep1,row.ep2);
+      const d = dist(row.cp, mp);
+      if (d != null && d > tol && hasDiag(row,'CP-TEE')) diagnostics.push(issue('error','FALLBACK-TEE-CP-MIDPOINT',row,'TEE CP fallback provenance exists but CP is not midpoint of EP1/EP2.',{expected:mp,actual:row.cp,distance:d}));
+    }
+    if ((row.branchBore == null || row.branchBore === '') && row.bore != null) diagnostics.push(issue('warning','FALLBACK-TEE-BRANCH-BORE-MISSING',row,'TEE branch bore missing; expected fallback to header bore.'));
+    if (row.branchBore != null && row.bore != null && hasDiag(row,'BORE-TEE-BRANCH') && !approx(row.branchBore,row.bore,tol)) diagnostics.push(issue('error','FALLBACK-TEE-BRANCH-BORE',row,'TEE branch bore fallback should equal header bore.',{expected:row.bore,actual:row.branchBore}));
+  }
+
+  if (t === 'BEND') {
+    if (point(row.ep1) && point(row.ep2) && point(row.cp)) {
+      const mp = midpoint(row.ep1,row.ep2);
+      const dMid = dist(row.cp, mp);
+      if (dMid != null && dMid <= tol && hasDiag(row,'CP-BEND')) diagnostics.push(issue('error','FALLBACK-BEND-CP-MIDPOINT',row,'BEND CP fallback must not use midpoint; expected corner intersection.'));
+      const r1 = dist(row.cp,row.ep1), r2 = dist(row.cp,row.ep2);
+      if (r1 != null && r2 != null && Math.abs(r1-r2) > tol) diagnostics.push(issue('warning','FALLBACK-BEND-RADIUS-MISMATCH',row,'BEND CP distances to EP1/EP2 are not equal.',{r1,r2}));
+    }
+  }
+
+  if (t === 'OLET') {
+    if ((row.branchBore == null || row.branchBore === '') && !hasDiag(row,'BORE-OLET-BRANCH')) diagnostics.push(issue('warning','FALLBACK-OLET-BRANCH-BORE-MISSING',row,'OLET branch bore missing without fallback provenance.'));
+    if (hasDiag(row,'BORE-OLET-BRANCH') && !approx(row.branchBore,50,tol)) diagnostics.push(issue('error','FALLBACK-OLET-BRANCH-BORE',row,'OLET branch bore fallback should be 50 mm.',{expected:50,actual:row.branchBore}));
+    if (!point(row.cp) && !hasDiag(row,'CP-OLET')) diagnostics.push(issue('warning','FALLBACK-OLET-CP-PROVENANCE',row,'OLET CP missing without fallback/deferred provenance.'));
+    if (!point(row.bp) && !hasDiag(row,'BP-OLET')) diagnostics.push(issue('warning','FALLBACK-OLET-BP-PROVENANCE',row,'OLET BP missing without fallback/incomplete provenance.'));
+  }
+
+  if (point(row.cp) && row.cpBore != null && row.bore != null && !approx(row.cpBore,row.bore,tol)) {
+    diagnostics.push(issue('error','FALLBACK-CP-BORE',row,'CP bore fallback must equal header/EP bore.',{expected:row.bore,actual:row.cpBore}));
+  }
+
+  const refNo = clean(row.refNo);
+  const csvSeq = clean(row.csvSeqNo);
+  if (!clean(row.ca97)) diagnostics.push(issue('warning','FALLBACK-CA97-MISSING',row,'CA97 missing; expected fallback from REF NO.'));
+  else if (refNo && clean(row.ca97) !== refNo && row?.trace?.fallbacks?.ca97) diagnostics.push(issue('error','FALLBACK-CA97',row,'CA97 fallback provenance exists but CA97 does not equal REF NO.',{expected:refNo,actual:row.ca97}));
+
+  if (!clean(row.ca98)) diagnostics.push(issue('warning','FALLBACK-CA98-MISSING',row,'CA98 missing; expected fallback from CSV SEQ NO.'));
+  else if (csvSeq && clean(row.ca98) !== csvSeq && row?.trace?.fallbacks?.ca98) diagnostics.push(issue('error','FALLBACK-CA98',row,'CA98 fallback provenance exists but CA98 does not equal CSV SEQ NO.',{expected:csvSeq,actual:row.ca98}));
+
+  return diagnostics;
+}
+
+export function validateFallbackRows(rows = [], options = {}) {
+  const diagnostics=[];
+  for(const row of Array.isArray(rows)?rows:[]) diagnostics.push(...validateFallbackRow(row,options));
+  return { pass: diagnostics.filter(d=>d.severity==='error').length===0, diagnostics, summary:{ rows:Array.isArray(rows)?rows.length:0, errors:diagnostics.filter(d=>d.severity==='error').length, warnings:diagnostics.filter(d=>d.severity==='warning').length } };
+}
+
+try { if (typeof window !== 'undefined') { window.validatePcfFallbackRows = validateFallbackRows; window.validatePcfFallbackRow = validateFallbackRow; } } catch (_) {}

--- a/js/pcf-engine/validators/formula-validator.js
+++ b/js/pcf-engine/validators/formula-validator.js
@@ -1,0 +1,92 @@
+/**
+ * formula-validator.js — Phase 5B Formula validation
+ *
+ * Validates calculated formula consistency:
+ * - LEN/AXIS from EP1/EP2 coordinates
+ * - EP ⇄ DELTA ⇄ LEN/AXIS consistency
+ * - BRLEN = magnitude(BP - CP), unless table/direct fallback source is recorded
+ * - DIAMETER = BORE
+ * - WALL_THICK = CA4
+ * - BEND_PTR/RIGID_PTR/INT_PTR counters when expected values are present
+ */
+
+import { calculateDeltaFromEps, calculateLenAxisFromDelta, calculateDeltaFromLenAxis } from '../geometry-sync.js';
+
+function clean(v) { return String(v ?? '').trim(); }
+function n(v, fallback = null) { if (v == null || v === '') return fallback; const x = Number(v); return Number.isFinite(x) ? x : fallback; }
+function point(p) { if (!p || typeof p !== 'object') return null; const x=n(p.x), y=n(p.y), z=n(p.z); return [x,y,z].every(v=>v!=null) ? {x,y,z} : null; }
+function approx(a, b, tol) { if (a == null && b == null) return true; if (a == null || b == null) return false; return Math.abs(Number(a)-Number(b)) <= tol; }
+function issue(severity, code, row, field, expected, actual, message) {
+  return { phase:'5B', validator:'formula-validator', severity, code, rowIndex: row?.rowIndex ?? null, refNo: row?.refNo || row?.ca97 || '', type: clean(row?.type || row?.rawType).toUpperCase(), field, expected, actual, message };
+}
+function magBpCp(row) { const cp=point(row?.cp), bp=point(row?.bp); if(!cp||!bp) return null; const dx=bp.x-cp.x, dy=bp.y-cp.y, dz=bp.z-cp.z; return Math.sqrt(dx*dx+dy*dy+dz*dz); }
+function ca4(row) { return clean(row?.ca?.['4'] ?? row?.ca4 ?? row?.CA4 ?? row?.['CA4'] ?? row?.['CA 4']); }
+function typeOf(row) { return clean(row?.type || row?.rawType).toUpperCase(); }
+
+export function validateFormulaRow(row, options = {}) {
+  const tol = Number(options.tolerance ?? 0.001);
+  const diagnostics = [];
+  const ep1 = point(row?.ep1);
+  const ep2 = point(row?.ep2);
+
+  if (ep1 && ep2) {
+    const delta = calculateDeltaFromEps(ep1, ep2);
+    const lenAxis = calculateLenAxisFromDelta(delta);
+    if (!approx(row?.deltaX, delta.x, tol)) diagnostics.push(issue('error','FORMULA-DELTA-X',row,'deltaX',delta.x,row?.deltaX,'DELTA_X must equal EP2.x - EP1.x.'));
+    if (!approx(row?.deltaY, delta.y, tol)) diagnostics.push(issue('error','FORMULA-DELTA-Y',row,'deltaY',delta.y,row?.deltaY,'DELTA_Y must equal EP2.y - EP1.y.'));
+    if (!approx(row?.deltaZ, delta.z, tol)) diagnostics.push(issue('error','FORMULA-DELTA-Z',row,'deltaZ',delta.z,row?.deltaZ,'DELTA_Z must equal EP2.z - EP1.z.'));
+
+    for (const f of ['len1','axis1','len2','axis2','len3','axis3']) {
+      const expected = lenAxis[f];
+      const actual = row?.[f];
+      if (expected == null || expected === '') {
+        if (actual != null && actual !== '' && Number(actual) !== 0) diagnostics.push(issue('warning',`FORMULA-${f.toUpperCase()}-ZERO`,row,f,expected,actual,`${f} should be blank/null when delta is zero.`));
+      } else if (f.startsWith('len')) {
+        if (!approx(actual, expected, tol)) diagnostics.push(issue('error',`FORMULA-${f.toUpperCase()}`,row,f,expected,actual,`${f} inconsistent with EP delta.`));
+      } else if (clean(actual).toLowerCase() !== clean(expected).toLowerCase()) {
+        diagnostics.push(issue('error',`FORMULA-${f.toUpperCase()}`,row,f,expected,actual,`${f} inconsistent with delta sign.`));
+      }
+    }
+  }
+
+  if ([row?.len1,row?.len2,row?.len3,row?.axis1,row?.axis2,row?.axis3].some(v => clean(v))) {
+    const d = calculateDeltaFromLenAxis(row);
+    if (row?.deltaX != null && !approx(row.deltaX, d.x, tol)) diagnostics.push(issue('error','FORMULA-LENAXIS-DELTA-X',row,'deltaX',d.x,row.deltaX,'DELTA_X inconsistent with LEN1/AXIS1.'));
+    if (row?.deltaY != null && !approx(row.deltaY, d.y, tol)) diagnostics.push(issue('error','FORMULA-LENAXIS-DELTA-Y',row,'deltaY',d.y,row.deltaY,'DELTA_Y inconsistent with LEN2/AXIS2.'));
+    if (row?.deltaZ != null && !approx(row.deltaZ, d.z, tol)) diagnostics.push(issue('error','FORMULA-LENAXIS-DELTA-Z',row,'deltaZ',d.z,row.deltaZ,'DELTA_Z inconsistent with LEN3/AXIS3.'));
+  }
+
+  const t = typeOf(row);
+  if (t === 'TEE' || t === 'OLET') {
+    const geomBrlen = magBpCp(row);
+    const brSrc = clean(row?.brlenResolution?.source);
+    const tableFallback = /table|Service|rc-config|direct-data-table/i.test(brSrc);
+    if (geomBrlen != null && row?.brlen != null && !tableFallback && !approx(row.brlen, geomBrlen, tol)) {
+      diagnostics.push(issue('error','FORMULA-BRLEN',row,'brlen',geomBrlen,row.brlen,'BRLEN must equal magnitude(BP - CP) unless table/direct fallback provenance is recorded.'));
+    }
+  }
+
+  if (row?.bore != null && row?.diameter != null && !approx(row.diameter, row.bore, tol)) {
+    diagnostics.push(issue('error','FORMULA-DIAMETER',row,'diameter',row.bore,row.diameter,'DIAMETER must equal BORE.'));
+  }
+
+  const wt = ca4(row);
+  if (wt && clean(row?.wallThick) && clean(row.wallThick) !== wt) {
+    diagnostics.push(issue('error','FORMULA-WALL-THICK',row,'wallThick',wt,row.wallThick,'WALL_THICK must equal CA4.'));
+  }
+
+  for (const ptr of ['bendPtr','rigidPtr','intPtr']) {
+    const expected = row?.calculatedColumns?.expected?.[ptr];
+    if (expected != null && !approx(row?.[ptr], expected, 0)) diagnostics.push(issue('error',`FORMULA-${ptr.toUpperCase()}`,row,ptr,expected,row?.[ptr],`${ptr} does not match expected pointer counter.`));
+  }
+
+  return diagnostics;
+}
+
+export function validateFormulaRows(rows = [], options = {}) {
+  const diagnostics = [];
+  for (const row of Array.isArray(rows) ? rows : []) diagnostics.push(...validateFormulaRow(row, options));
+  return { pass: diagnostics.filter(d=>d.severity==='error').length === 0, diagnostics, summary: { rows: Array.isArray(rows)?rows.length:0, errors: diagnostics.filter(d=>d.severity==='error').length, warnings: diagnostics.filter(d=>d.severity==='warning').length } };
+}
+
+try { if (typeof window !== 'undefined') { window.validatePcfFormulaRows = validateFormulaRows; window.validatePcfFormulaRow = validateFormulaRow; } } catch (_) {}

--- a/js/pcf-engine/validators/pcf-output-validator.js
+++ b/js/pcf-engine/validators/pcf-output-validator.js
@@ -1,0 +1,59 @@
+/**
+ * pcf-output-validator.js — Phase 5E generated PCF syntax/structure checks
+ */
+
+const TOP_LEVEL = new Set(['ISOGEN-FILES','UNITS-BORE','UNITS-CO-ORDS','UNITS-WEIGHT','UNITS-BOLT-DIA','UNITS-BOLT-LENGTH','PIPELINE-REFERENCE','MESSAGE-SQUARE','PIPE','FLANGE','BEND','TEE','OLET','VALVE','REDUCER-CONCENTRIC','REDUCER-ECCENTRIC','SUPPORT','MISC-COMPONENT']);
+const BLOCKS = new Set(['PIPE','FLANGE','BEND','TEE','OLET','VALVE','REDUCER-CONCENTRIC','REDUCER-ECCENTRIC','SUPPORT','MISC-COMPONENT']);
+const CA8_ALLOWED = new Set(['FLANGE','VALVE']);
+function clean(v){ return String(v ?? '').trim(); }
+function issue(severity,code,message,extra={}){ return { phase:'5E', validator:'pcf-output-validator', severity, code, message, ...extra }; }
+function parseNum(s){ const n = Number.parseFloat(String(s)); return Number.isFinite(n) ? n : null; }
+function validateCoordPrecision(line, decimals, diagnostics, lineNo){
+  const nums = clean(line).split(/\s+/).slice(1).map(parseNum).filter(v=>v!=null);
+  if (nums.length < 4) return;
+  const parts = clean(line).split(/\s+/).slice(1,5);
+  for (const p of parts) {
+    const m = String(p).match(/^-?\d+(?:\.(\d+))?$/);
+    const actual = m?.[1]?.length ?? 0;
+    if (actual !== decimals) diagnostics.push(issue('error','PCF-DECIMAL-PRECISION',`Coordinate value ${p} does not match configured decimal precision ${decimals}.`,{lineNo,line}));
+  }
+}
+function parseBlocks(lines){
+  const out=[]; let cur=null;
+  const flush=()=>{ if(cur) out.push(cur); cur=null; };
+  for(let i=0;i<lines.length;i++){
+    const t=lines[i].trim();
+    if(BLOCKS.has(t)){ flush(); cur={type:t,lineNo:i+1,lines:[]}; continue; }
+    if(cur) cur.lines.push({lineNo:i+1,text:lines[i]});
+  }
+  flush(); return out;
+}
+export function validatePcfOutputText(pcfText, options={}){
+  const diagnostics=[];
+  const decimals = Number.isInteger(options.decimalPrecision) ? options.decimalPrecision : 4;
+  if (options.requireCrlf !== false && /(?<!\r)\n/.test(String(pcfText||''))) diagnostics.push(issue('error','PCF-LINE-ENDINGS','PCF output must use CRLF line endings when configured.'));
+  const lines = String(pcfText||'').split(/\r?\n/);
+  for(let i=0;i<lines.length;i++){
+    const raw=lines[i]; const t=raw.trim(); if(!t) continue;
+    const keyword=t.split(/\s+/)[0];
+    if (TOP_LEVEL.has(keyword) || TOP_LEVEL.has(t)) {
+      if (/^\s+/.test(raw)) diagnostics.push(issue('error','PCF-TOP-INDENT','Top-level PCF keyword must not be indented.',{lineNo:i+1,line:raw}));
+    } else {
+      if (!raw.startsWith('    ')) diagnostics.push(issue('error','PCF-SUBLINE-INDENT','PCF sub-line must be indented by 4 spaces.',{lineNo:i+1,line:raw}));
+    }
+    if (/^(\s*)(END-POINT|CENTRE-POINT|BRANCH1-POINT|CO-ORDS)\b/.test(raw)) validateCoordPrecision(raw,decimals,diagnostics,i+1);
+  }
+  const blocks=parseBlocks(lines);
+  for(const b of blocks){
+    const textLines=b.lines.map(x=>x.text.trim());
+    if(b.type==='SUPPORT'){
+      if(!textLines.some(l=>l.startsWith('CO-ORDS'))) diagnostics.push(issue('error','PCF-SUPPORT-COORDS','SUPPORT must include CO-ORDS.',{block:b}));
+      if(!textLines.some(l=>l.startsWith('<SUPPORT_NAME>'))) diagnostics.push(issue('error','PCF-SUPPORT-NAME','SUPPORT must include <SUPPORT_NAME>.',{block:b}));
+      if(textLines.some(l=>/^COMPONENT-ATTRIBUTE\d+\b/.test(l))) diagnostics.push(issue('error','PCF-SUPPORT-CA','SUPPORT must not include CA1–CA10 lines.',{block:b}));
+    }
+    if(b.type==='OLET' && textLines.some(l=>l.startsWith('END-POINT'))) diagnostics.push(issue('error','PCF-OLET-ENDPOINT','OLET must not include END-POINT lines.',{block:b}));
+    if(!CA8_ALLOWED.has(b.type) && textLines.some(l=>/^COMPONENT-ATTRIBUTE8\b/.test(l))) diagnostics.push(issue('error','PCF-CA8-SCOPE',`CA8 is not allowed on ${b.type}.`,{block:b}));
+  }
+  return { pass: diagnostics.filter(d=>d.severity==='error').length===0, diagnostics, summary:{ blocks:blocks.length, errors:diagnostics.filter(d=>d.severity==='error').length, warnings:diagnostics.filter(d=>d.severity==='warning').length } };
+}
+try { if(typeof window!=='undefined') window.validatePcfOutputText = validatePcfOutputText; } catch(_) {}

--- a/js/pcf-engine/validators/skey-validator.js
+++ b/js/pcf-engine/validators/skey-validator.js
@@ -1,0 +1,139 @@
+/**
+ * skey-validator.js — Phase 5A <SKEY> validation
+ *
+ * Rules:
+ * - PCF keyword must be <SKEY> with angle brackets.
+ * - PIPE and SUPPORT do not require SKEY.
+ * - FLANGE, VALVE, BEND, TEE, OLET, REDUCER-C, REDUCER-E require SKEY.
+ */
+
+const RULES = Object.freeze({
+  PIPE: { mandatory: false, allowed: [] },
+  SUPPORT: { mandatory: false, allowed: [] },
+  FLANGE: { mandatory: true, allowed: ['FLWN', 'FLSO', 'FLBL', 'FLLJ', 'BLFL'] },
+  VALVE: { mandatory: true, allowed: ['VBFL', 'VGAT', 'VGLB', 'VCHK', 'VBAL'] },
+  BEND: { mandatory: true, allowed: ['BEBW', 'BESW'] },
+  TEE: { mandatory: true, allowed: ['TEBW', 'TESW'] },
+  OLET: { mandatory: true, allowed: ['OLWL', 'OLSO'] },
+  'REDUCER-CONCENTRIC': { mandatory: true, allowed: ['RCBW'] },
+  'REDUCER-ECCENTRIC': { mandatory: true, allowed: ['REBW'] },
+  'REDUCER-C': { mandatory: true, allowed: ['RCBW'] },
+  'REDUCER-E': { mandatory: true, allowed: ['REBW'] },
+});
+
+function clean(v) {
+  return String(v ?? '').trim();
+}
+
+function typeOf(row) {
+  const t = clean(row?.type || row?.rawType || row?.blockType).toUpperCase();
+  if (t === 'REDU') return 'REDUCER-CONCENTRIC';
+  return t;
+}
+
+function skeyOf(row) {
+  return clean(row?.skey || row?.SKEY || row?.['<SKEY>']).toUpperCase();
+}
+
+function issue(severity, code, row, message, extra = {}) {
+  return {
+    phase: '5A',
+    validator: 'skey-validator',
+    severity,
+    code,
+    rowIndex: row?.rowIndex ?? row?.index ?? null,
+    refNo: row?.refNo || row?.ca97 || row?.source?.originalRefNo || '',
+    type: typeOf(row),
+    message,
+    ...extra,
+  };
+}
+
+export function validateSkeyRow(row, options = {}) {
+  const diagnostics = [];
+  const type = typeOf(row);
+  const skey = skeyOf(row);
+  const rules = { ...RULES, ...(options.rules || {}) };
+  const rule = rules[type];
+
+  if (!rule) {
+    diagnostics.push(issue('warning', 'SKEY-UNKNOWN-TYPE', row, `No SKEY rule registered for component type ${type || '(blank)'}.`));
+    return diagnostics;
+  }
+
+  if (rule.mandatory && !skey) {
+    diagnostics.push(issue('error', 'SKEY-MISSING', row, `${type} requires <SKEY>.`, { allowed: rule.allowed }));
+    return diagnostics;
+  }
+
+  if (skey && Array.isArray(rule.allowed) && rule.allowed.length && !rule.allowed.includes(skey)) {
+    diagnostics.push(issue(options.invalidSeverity || 'warning', 'SKEY-NONSTANDARD', row, `${type} has non-standard <SKEY> ${skey}.`, { skey, allowed: rule.allowed }));
+  }
+
+  return diagnostics;
+}
+
+export function validateSkeyRows(rows = [], options = {}) {
+  const diagnostics = [];
+  for (const row of Array.isArray(rows) ? rows : []) {
+    diagnostics.push(...validateSkeyRow(row, options));
+  }
+  return {
+    pass: diagnostics.filter(d => d.severity === 'error').length === 0,
+    diagnostics,
+    summary: {
+      rows: Array.isArray(rows) ? rows.length : 0,
+      errors: diagnostics.filter(d => d.severity === 'error').length,
+      warnings: diagnostics.filter(d => d.severity === 'warning').length,
+    },
+  };
+}
+
+export function validateSkeyInPcfText(pcfText, options = {}) {
+  const lines = String(pcfText || '').split(/\r?\n/);
+  const diagnostics = [];
+  let currentType = '';
+  let currentHasSkey = false;
+  let currentLine = 0;
+
+  const flush = () => {
+    if (!currentType) return;
+    diagnostics.push(...validateSkeyRow({ type: currentType, skey: currentHasSkey ? 'PRESENT' : '', rowIndex: currentLine }, {
+      ...options,
+      invalidSeverity: 'info',
+      rules: Object.fromEntries(Object.entries({ ...RULES, ...(options.rules || {}) }).map(([k, v]) => [k, { ...v, allowed: [] }]))
+    }));
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (RULES[t]) {
+      flush();
+      currentType = t;
+      currentHasSkey = false;
+      currentLine = i + 1;
+    } else if (t.startsWith('<SKEY>')) {
+      currentHasSkey = true;
+    } else if (/^SKEY\b|^S-Key\b|^COMPONENT-KEY\b/i.test(t)) {
+      diagnostics.push(issue('error', 'SKEY-KEYWORD-FORM', { type: currentType, rowIndex: i + 1 }, 'SKEY keyword must be exactly <SKEY> with angle brackets.', { line: t }));
+    }
+  }
+  flush();
+
+  return {
+    pass: diagnostics.filter(d => d.severity === 'error').length === 0,
+    diagnostics,
+    summary: {
+      errors: diagnostics.filter(d => d.severity === 'error').length,
+      warnings: diagnostics.filter(d => d.severity === 'warning').length,
+    },
+  };
+}
+
+try {
+  if (typeof window !== 'undefined') {
+    window.validatePcfSkeyRows = validateSkeyRows;
+    window.validatePcfSkeyRow = validateSkeyRow;
+    window.validatePcfSkeyText = validateSkeyInPcfText;
+  }
+} catch (_) {}

--- a/js/ray-concept/rc-stage4-dispatcher.js
+++ b/js/ray-concept/rc-stage4-dispatcher.js
@@ -1,0 +1,79 @@
+/**
+ * rc-stage4-dispatcher.js — Phase 3A Common/Legacy Stage 4 router
+ *
+ * Keeps the large legacy emitter untouched and routes Stage 4 by engineMode.
+ *
+ * Usage:
+ *   import { runStage4 } from './rc-stage4-dispatcher.js';
+ *
+ * Engine source priority:
+ *   1. options.engineMode
+ *   2. localStorage('pcfStudio.engineMode')
+ *   3. getRayConfig().engineMode
+ *   4. 'legacy'
+ */
+
+import { getRayConfig } from './rc-config.js';
+import { runStage4 as runStage4Legacy } from './rc-stage4-emitter.js';
+import { buildCommonPcf } from '../pcf-engine/common-pcf-builder.js';
+
+function resolveEngineMode(options = {}, cfg = {}) {
+  let storageMode = '';
+  try {
+    storageMode = localStorage.getItem('pcfStudio.engineMode') || '';
+  } catch (_) {
+    storageMode = '';
+  }
+
+  return String(
+    options.engineMode ||
+    storageMode ||
+    cfg.engineMode ||
+    'legacy'
+  ).trim().toLowerCase();
+}
+
+function exposeLastStage4Run(result, mode) {
+  try {
+    window.__RAY_STAGE4_LAST_RUN__ = {
+      mode,
+      resultMeta: result?.meta || null,
+      commonMeta: window.__COMMON_PCF_BUILDER_LAST_RUN__?.meta || null,
+      timestamp: Date.now(),
+    };
+  } catch (_) {
+    // non-browser execution
+  }
+}
+
+export function runStage4(components, injectedPipes, pipelineRef, logFn = () => {}, options = {}) {
+  const cfg = getRayConfig();
+  const mode = resolveEngineMode(options, cfg);
+
+  if (mode === 'common') {
+    const result = buildCommonPcf({
+      components,
+      injectedPipes,
+      pipelineRef,
+      cfg: { ...cfg, engineMode: 'common' },
+      logFn,
+      legacyEmitter: runStage4Legacy,
+    });
+
+    exposeLastStage4Run(result, 'common');
+    return result;
+  }
+
+  const result = runStage4Legacy(components, injectedPipes, pipelineRef, logFn);
+  exposeLastStage4Run(result, 'legacy');
+  return {
+    ...result,
+    meta: {
+      ...(result?.meta || {}),
+      engine: 'legacy',
+      emittedBy: 'rc-stage4-emitter',
+    },
+  };
+}
+
+export { runStage4Legacy };


### PR DESCRIPTION
## Summary

Implements Phase 2 of the Common PCF Builder work:

- Adds `js/pcf-engine/pcf-model-emitter.js` to emit PCF directly from the canonical Common Builder model.
- Adds `js/pcf-engine/pcf-output-diff.js` to parse and compare Legacy vs Common PCF output block-by-block.
- Updates `js/pcf-engine/common-pcf-builder.js` from Phase 1 delegation mode to Phase 2 direct Common model emission.
- Stores browser proof metadata in `window.__COMMON_PCF_BUILDER_LAST_RUN__`, including `commonText`, `legacyText`, diagnostics, and diff summary.

## Current behavior

Common Builder now emits through `pcf-model-emitter.js` and uses legacy only for comparison when a legacy emitter callback is supplied.

Expected browser metadata after Common run:

```js
window.__COMMON_PCF_BUILDER_LAST_RUN__.meta
// engine: 'common'
// phase: 'phase2-common-model-emitter'
// emittedBy: 'pcf-model-emitter'
```

## Important note

This PR adds the Phase 2 Common Builder engine modules. The Stage 4 UI dispatch wrapper must route `engineMode === 'common'` into `buildCommonPcf(...)` for the Ray UI toggle to execute the Common path. If that wiring is not already present locally, apply the Stage 4 dispatcher patch from the implementation notes.

## Validation target

For each benchmark CSV/PCF:

- Common output is produced.
- `meta.blockCount > 0`.
- `diagnostics.errors === 0` for valid fixtures.
- `diff.summary.critical === 0` and `diff.summary.major === 0` before marking Common Builder production-ready.

## Files changed

- `js/pcf-engine/common-pcf-builder.js`
- `js/pcf-engine/pcf-model-emitter.js`
- `js/pcf-engine/pcf-output-diff.js`