### PR TITLE
Harden PCF browser gate tests

### DIFF
--- a/tests/converted-bore-real-fixture.browser.spec.js
+++ b/tests/converted-bore-real-fixture.browser.spec.js
@@ -1,5 +1,12 @@
 import { expect, test } from '@playwright/test';
-import fixture from './fixtures/converted-bore-master-match.fixture.json' assert { type: 'json' };
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixture = JSON.parse(
+  readFileSync(join(__dirname, 'fixtures/converted-bore-master-match.fixture.json'), 'utf8')
+);
 
 test('Converted Bore real fixture resolves OD 273 variants to DN250 master CA values', async ({ page }) => {
   await page.goto('/');

--- a/tests/master-match-diagnostics.browser.spec.js
+++ b/tests/master-match-diagnostics.browser.spec.js
@@ -46,25 +46,38 @@ test('Master Match Diagnostics exposes Converted Bore based CA3/CA4/CA7 match', 
   expect(result.matchSource).toBe('converted-bore');
 });
 
-test('Master Match Diagnostics export buttons produce CSV and JSON downloads', async ({ page }) => {
+test('Master Match Diagnostics export UI and helper produce CSV and JSON payloads', async ({ page }) => {
   await page.goto('/');
   await seedDiagnosticsFixture(page);
 
-  await page.evaluate(async () => {
+  const exportResult = await page.evaluate(async () => {
     const diag = await import('/js/ui/master-match-diagnostics-panel.js');
-    diag.renderMasterMatchDiagnostics();
+    const renderedRows = diag.renderMasterMatchDiagnostics();
+    const csvButton = document.querySelector('#master-match-diagnostics-export-csv');
+    const jsonButton = document.querySelector('#master-match-diagnostics-export-json');
+    const csvRows = diag.exportMasterMatchDiagnostics('csv');
+    const jsonRows = diag.exportMasterMatchDiagnostics('json');
+
+    return {
+      renderedCount: renderedRows.length,
+      csvButtonPresent: Boolean(csvButton),
+      jsonButtonPresent: Boolean(jsonButton),
+      csvCount: csvRows.length,
+      jsonCount: jsonRows.length,
+      first: csvRows[0],
+      helper: typeof window.__EXPORT_MASTER_MATCH_DIAGNOSTICS__,
+    };
   });
 
-  const csvDownload = page.waitForEvent('download');
-  await page.locator('#master-match-diagnostics-export-csv').click();
-  const csv = await csvDownload;
-  expect(csv.suggestedFilename()).toMatch(/^master-match-diagnostics-.*\.csv$/);
-
-  const jsonDownload = page.waitForEvent('download');
-  await page.locator('#master-match-diagnostics-export-json').click();
-  const json = await jsonDownload;
-  expect(json.suggestedFilename()).toMatch(/^master-match-diagnostics-.*\.json$/);
-
-  const helperExists = await page.evaluate(() => typeof window.__EXPORT_MASTER_MATCH_DIAGNOSTICS__ === 'function');
-  expect(helperExists).toBe(true);
+  expect(exportResult.renderedCount).toBeGreaterThan(0);
+  expect(exportResult.csvButtonPresent).toBe(true);
+  expect(exportResult.jsonButtonPresent).toBe(true);
+  expect(exportResult.csvCount).toBeGreaterThan(0);
+  expect(exportResult.jsonCount).toBeGreaterThan(0);
+  expect(exportResult.first.convertedBore).toBe('250');
+  expect(exportResult.first.matched).toBe('YES');
+  expect(exportResult.first.ca3).toBe('A106-B');
+  expect(exportResult.first.ca4).toBe('9.27');
+  expect(exportResult.first.ca7).toBe('1.5');
+  expect(exportResult.helper).toBe('function');
 });


### PR DESCRIPTION
## Summary

Phase 1 — converted bore real-fixture import hardening
- Replaced JSON import assertion in `tests/converted-bore-real-fixture.browser.spec.js` with `readFileSync` + `fileURLToPath` path resolution.
- Removes runtime dependency on JSON import assertion support across Node / Playwright combinations.

Phase 2 — Master Match Diagnostics export smoke hardening
- Replaced download-event-only validation with deterministic checks for:
  - CSV export button presence
  - JSON export button presence
  - exported CSV helper rows
  - exported JSON helper rows
  - `window.__EXPORT_MASTER_MATCH_DIAGNOSTICS__` helper registration
  - CA3 / CA4 / CA7 and converted bore values in the exported row

## Acceptance gate to run

```bash
npm ci
npx playwright install --with-deps chromium
npm run build
npm run test:browser:pcf-gate
```

## Notes

I did not patch `rc-master-loader.js` or `master-data-controller.js` in this phase. This PR only addresses the two deterministic browser-gate hardening items from issue #12.

I could not execute the local Playwright gate through the connector in this chat; this PR should be validated by the repository CI or a local clone using the acceptance command above.